### PR TITLE
feat: add `cyto summary` HTML QC report command

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,12 +7,24 @@ env:
 
 jobs:
   ci:
-    needs: [build, test, linting, integration]
+    needs: [build, test, linting, integration, build-h5ad]
     name: CI
     runs-on: "ubuntu-latest"
     steps:
       - name: Done
         run: exit 0
+
+  build-h5ad:
+    name: Build (h5ad feature)
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install libhdf5
+        run: sudo apt-get update && sudo apt-get install -y libhdf5-dev pkg-config
+      - name: Build and test with h5ad feature
+        run: |
+          cargo build -p cyto --features h5ad --verbose
+          cargo test -p cyto-summary --features h5ad --verbose
 
   linting:
     name: Linting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Workspace uses pedantic clippy lints with specific exceptions defined in root Ca
 
 ## Architecture
 
-### Crate Organization (11 crates in `crates/`)
+### Crate Organization (12 crates in `crates/`)
 
 **Entry Points:**
 
@@ -91,6 +91,10 @@ Workspace uses pedantic clippy lints with specific exceptions defined in root Ca
 - `cyto-map` - Maps reads to features (barcode correction, optional probe demux, geometry handling)
 - `cyto-workflow` - Orchestrates multi-step pipelines (gex, crispr workflows)
 - `cyto-io` - File I/O utilities
+
+**Reporting:**
+
+- `cyto-summary` - Aggregates per-stage `stats/` files into self-contained HTML QC reports (per-sample + master index)
 
 **IBU (Index-Barcode-UMI) Format Processing:**
 
@@ -114,6 +118,7 @@ cyto
 ├── detect
 │   ├── gex        # Auto-detect GEX read geometry
 │   └── crispr     # Auto-detect CRISPR read geometry
+├── summary        # Aggregate finished output dir(s) into HTML QC reports
 └── ibu
     ├── view, sort, count, cat, umi, reads
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ just install
 
 ### Dependencies
 
+System `libhdf5` is required to build (the `cyto-summary` crate links it for
+genes/guides-detected metrics). Install e.g. `libhdf5-dev`; it is located via
+`pkg-config` at build time.
+
 Not strictly necessary but recommended: `bqtools`
 
 - If not installed, run `cargo install bqtools`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,10 @@ just install
 
 ### Dependencies
 
-System `libhdf5` is required to build (the `cyto-summary` crate links it for
-genes/guides-detected metrics). Install e.g. `libhdf5-dev`; it is located via
-`pkg-config` at build time.
+The optional `h5ad` cargo feature (off by default) links system `libhdf5` for
+`cyto summary`'s genes/guides-detected metrics. The default build needs no
+libhdf5; build with `cargo install --path crates/cyto --features h5ad`
+(or `just install-h5ad`) to enable it (`libhdf5-dev`, located via `pkg-config`).
 
 Not strictly necessary but recommended: `bqtools`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ cyto-cli = { path = "crates/cyto-cli", version = "0.7.3" }
 cyto-download = { path = "crates/cyto-download", version = "0.1.0" }
 cyto-io = { path = "crates/cyto-io", version = "0.2.0" }
 cyto-map = { path = "crates/cyto-map", version = "0.5.3" }
+cyto-summary = { path = "crates/cyto-summary", version = "0.1.0" }
 cyto-workflow = { path = "crates/cyto-workflow", version = "0.3.1" }
 
 anyhow = "1.0.102"

--- a/README.md
+++ b/README.md
@@ -155,6 +155,28 @@ output_dir/
     └── output.counts.tsv    # Single count matrix
 ```
 
+### QC Reports
+
+`cyto summary` turns one or more finished output directories into self-contained
+HTML QC reports (with machine-readable JSON sidecars), aggregating the per-stage
+stat files each workflow already wrote — no reprocessing of reads.
+
+```bash
+# One sample directory, a parent of several, or an explicit list
+cyto summary ./cyto_out
+cyto summary run/*/cyto_out
+```
+
+Each sample gets a `<sample>.cyto-report.html` (headline metrics, read-mapping
+funnel, per-probe table, barcode-rank plot, CRISPR guide multiplicity, timing);
+when several samples are present a `<run>.cyto-report.html` master index links
+them, split by library type. Reports default to `<parent>/cyto_reports/`.
+
+Pass `--features` to also report genes/guides detected by reading the count
+matrices. This requires a build with HDF5 support (`just install-h5ad` or
+`cargo install --path crates/cyto --features h5ad`), which links system
+`libhdf5`; the default build omits it.
+
 ## Input Formats
 
 ### Feature Libraries

--- a/crates/cyto-cli/CLAUDE.md
+++ b/crates/cyto-cli/CLAUDE.md
@@ -7,7 +7,7 @@ Defines all CLI argument structures using Clap. This crate is a pure definition 
 ## Key Source Files
 
 - `src/commands.rs` — Top-level `Commands` enum (`Workflow`, `Map`, `Detect`, `Ibu`, `Summary`, `Download`)
-- `src/summary/mod.rs` — `ArgsSummary` (inputs, output dir, run name, `--no-json`/`--no-master`/`--no-features`, `--rank-points`) for the `summary` command
+- `src/summary/mod.rs` — `ArgsSummary` (inputs, output dir, run name, `--no-json`/`--no-master`/`--features`, `--rank-points`) for the `summary` command (`--features` is opt-in and needs a build with the `h5ad` feature)
 - `src/map/mod.rs` — `MapCommand` enum (Gex, Crispr) and geometry preset string constants (`GEOMETRY_GEX_FLEX_V1`, `GEOMETRY_GEX_FLEX_V2`, etc.)
 - `src/map/options.rs` — `MapOptions` (geometry DSL, preset selection, exact matching, remap window), `GeometryPreset` enum, `WhitelistOptions`, `ProbeOptions`
 - `src/map/input.rs` — `MultiPairedInput` handles both BINSEQ (`.bq`/`.vbq`/`.cbq`) and FASTX paired-end inputs

--- a/crates/cyto-cli/CLAUDE.md
+++ b/crates/cyto-cli/CLAUDE.md
@@ -7,7 +7,7 @@ Defines all CLI argument structures using Clap. This crate is a pure definition 
 ## Key Source Files
 
 - `src/commands.rs` — Top-level `Commands` enum (`Workflow`, `Map`, `Detect`, `Ibu`, `Summary`, `Download`)
-- `src/summary/mod.rs` — `ArgsSummary` (inputs, output dir, run name, `--no-json`/`--no-master`, `--rank-points`) for the `summary` command
+- `src/summary/mod.rs` — `ArgsSummary` (inputs, output dir, run name, `--no-json`/`--no-master`/`--no-features`, `--rank-points`) for the `summary` command
 - `src/map/mod.rs` — `MapCommand` enum (Gex, Crispr) and geometry preset string constants (`GEOMETRY_GEX_FLEX_V1`, `GEOMETRY_GEX_FLEX_V2`, etc.)
 - `src/map/options.rs` — `MapOptions` (geometry DSL, preset selection, exact matching, remap window), `GeometryPreset` enum, `WhitelistOptions`, `ProbeOptions`
 - `src/map/input.rs` — `MultiPairedInput` handles both BINSEQ (`.bq`/`.vbq`/`.cbq`) and FASTX paired-end inputs

--- a/crates/cyto-cli/CLAUDE.md
+++ b/crates/cyto-cli/CLAUDE.md
@@ -6,7 +6,8 @@ Defines all CLI argument structures using Clap. This crate is a pure definition 
 
 ## Key Source Files
 
-- `src/commands.rs` — Top-level `Commands` enum (`Workflow`, `Map`, `Detect`, `Ibu`)
+- `src/commands.rs` — Top-level `Commands` enum (`Workflow`, `Map`, `Detect`, `Ibu`, `Summary`, `Download`)
+- `src/summary/mod.rs` — `ArgsSummary` (inputs, output dir, run name, `--no-json`/`--no-master`, `--rank-points`) for the `summary` command
 - `src/map/mod.rs` — `MapCommand` enum (Gex, Crispr) and geometry preset string constants (`GEOMETRY_GEX_FLEX_V1`, `GEOMETRY_GEX_FLEX_V2`, etc.)
 - `src/map/options.rs` — `MapOptions` (geometry DSL, preset selection, exact matching, remap window), `GeometryPreset` enum, `WhitelistOptions`, `ProbeOptions`
 - `src/map/input.rs` — `MultiPairedInput` handles both BINSEQ (`.bq`/`.vbq`/`.cbq`) and FASTX paired-end inputs

--- a/crates/cyto-cli/src/commands.rs
+++ b/crates/cyto-cli/src/commands.rs
@@ -1,6 +1,6 @@
 use clap::Subcommand;
 
-use super::{ArgsDownload, DetectCommand, IbuCommand, MapCommand, WorkflowCommand};
+use super::{ArgsDownload, ArgsSummary, DetectCommand, IbuCommand, MapCommand, WorkflowCommand};
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
@@ -19,6 +19,9 @@ pub enum Commands {
     /// Perform operations on an IBU library
     #[clap(subcommand)]
     Ibu(IbuCommand),
+
+    /// Generate HTML QC reports from finished output directories
+    Summary(ArgsSummary),
 
     /// Download reference resources to ~/.cyto/
     Download(ArgsDownload),

--- a/crates/cyto-cli/src/lib.rs
+++ b/crates/cyto-cli/src/lib.rs
@@ -4,6 +4,7 @@ pub mod download;
 pub mod ibu;
 pub mod map;
 mod output;
+pub mod summary;
 pub mod workflow;
 
 pub use commands::Commands;
@@ -12,4 +13,5 @@ pub use download::ArgsDownload;
 pub use ibu::IbuCommand;
 pub use map::{ArgsCrispr, ArgsGex, MapCommand};
 pub use output::ArgsOutput;
+pub use summary::ArgsSummary;
 pub use workflow::{ArgsWorkflow, WorkflowCommand, WorkflowMode};

--- a/crates/cyto-cli/src/summary/mod.rs
+++ b/crates/cyto-cli/src/summary/mod.rs
@@ -34,6 +34,13 @@ pub struct ArgsSummary {
     #[clap(long)]
     pub no_master: bool,
 
+    /// Skip reading count matrices for genes/guides-detected metrics
+    ///
+    /// Reading the h5ad panels adds a pass over the count matrices; disable it
+    /// for a faster, metrics-only report.
+    #[clap(long)]
+    pub no_features: bool,
+
     /// Number of points to sample for each barcode-rank plot polyline
     #[clap(long, default_value_t = 400)]
     pub rank_points: usize,

--- a/crates/cyto-cli/src/summary/mod.rs
+++ b/crates/cyto-cli/src/summary/mod.rs
@@ -34,12 +34,12 @@ pub struct ArgsSummary {
     #[clap(long)]
     pub no_master: bool,
 
-    /// Skip reading count matrices for genes/guides-detected metrics
+    /// Read count matrices (h5ad) to report genes/guides detected
     ///
-    /// Reading the h5ad panels adds a pass over the count matrices; disable it
-    /// for a faster, metrics-only report.
+    /// Adds a pass over each count matrix, so it is opt-in. Requires a build with
+    /// the `h5ad` feature (`cargo install --features h5ad`); otherwise ignored.
     #[clap(long)]
-    pub no_features: bool,
+    pub features: bool,
 
     /// Number of points to sample for each barcode-rank plot polyline
     #[clap(long, default_value_t = 400)]

--- a/crates/cyto-cli/src/summary/mod.rs
+++ b/crates/cyto-cli/src/summary/mod.rs
@@ -1,0 +1,40 @@
+use std::path::PathBuf;
+
+/// Arguments for the `summary` command.
+///
+/// Consumes one or more finished cyto output directories and renders
+/// self-contained HTML QC reports (plus machine-readable JSON sidecars).
+#[derive(clap::Parser, Debug)]
+pub struct ArgsSummary {
+    /// One or more finished cyto output directories.
+    ///
+    /// Each path may be a single sample directory (containing `stats/`), or a
+    /// parent directory holding several sample directories -- in which case the
+    /// sample directories are auto-discovered.
+    #[clap(required = true, num_args = 1..)]
+    pub inputs: Vec<PathBuf>,
+
+    /// Directory to write reports into
+    ///
+    /// [default: `<common-parent>/cyto_reports`]
+    #[clap(short, long)]
+    pub outdir: Option<PathBuf>,
+
+    /// Name used for the master report title and filename
+    ///
+    /// [default: the name of the common parent directory]
+    #[clap(long)]
+    pub run_name: Option<String>,
+
+    /// Do not write the machine-readable JSON sidecar per sample
+    #[clap(long)]
+    pub no_json: bool,
+
+    /// Do not write a master report even when multiple samples are present
+    #[clap(long)]
+    pub no_master: bool,
+
+    /// Number of points to sample for each barcode-rank plot polyline
+    #[clap(long, default_value_t = 400)]
+    pub rank_points: usize,
+}

--- a/crates/cyto-summary/CLAUDE.md
+++ b/crates/cyto-summary/CLAUDE.md
@@ -32,11 +32,12 @@ present, and a `<sample>.cyto-report.json` machine-readable sidecar per sample
   expansion; `read_reads()` parses `reads.tsv.zst` (via `cyto_io::match_input_transparent`)
   into totals, medians, and the log-spaced barcode-rank `knee_points()`;
   `detect_kind()` classifies GEX vs CRISPR from `.done`/stats subdirs.
-- `src/render.rs` — HTML rendering. Inlined CSS (`CSS`), hand-built SVG barcode-rank
-  plot (`knee_svg`), and card builders (`mapping_card`, `probe_table`, `moi_card`,
-  `timings_card`, `libraries_card`, `notes_card`, `sample_kpis`). Entry points:
-  `render_sample()` and `render_master()`. Formatting helpers: `int`, `compact`,
-  `pct`, `f1`, `esc`, `hbar`, `kpi`, `page`.
+- `src/render.rs` — HTML rendering. Inlined CSS (`CSS`, a white "printout" theme),
+  hand-built SVG barcode-rank plot (`knee_svg`), and section builders
+  (`sample_metrics`, `cells_section`, `mapping_section`, `probe_section`,
+  `moi_section`, `timing_section`, `library_section`, `alerts`). Entry points:
+  `render_sample()` and `render_master()`. Formatting/layout helpers: `int`,
+  `compact`, `pct`, `f1`, `esc`, `metric`, `eyebrow`, `bar`, `page`, `footer`.
 
 ## Design Notes
 
@@ -47,6 +48,11 @@ present, and a `<sample>.cyto-report.json` machine-readable sidecar per sample
 - **Self-contained output**: all CSS inlined, plots emitted as inline SVG (no JS,
   no external assets, no plotting dependency). A report is one portable file, KB-
   sized rather than the tens of MB a Cell Ranger `web_summary.html` embeds.
+- **Visual style**: a flat white "sequencing QC printout" -- hairline rules rather
+  than filled cards, all numeric data in tabular monospace, one restrained accent,
+  eyebrow section labels. Layout order follows what single-cell users know from
+  Cell Ranger (headline metrics -> metrics-left / barcode-rank-right -> mapping ->
+  per-probe) without copying its styling. Light theme only (no system fonts fetched).
 - **Robustness**: every panel is guarded. A sample missing `stats/filtering` or a
   malformed JSON still produces a report; issues surface in the Notes card.
 - Metrics richer than Cell Ranger where cyto has them: per-reason unmapped

--- a/crates/cyto-summary/CLAUDE.md
+++ b/crates/cyto-summary/CLAUDE.md
@@ -32,11 +32,14 @@ present, and a `<sample>.cyto-report.json` machine-readable sidecar per sample
   expansion; `read_reads()` parses `reads.tsv.zst` (via `cyto_io::match_input_transparent`)
   into totals, medians, and the log-spaced barcode-rank `knee_points()`;
   `detect_kind()` classifies GEX vs CRISPR from `.done`/stats subdirs.
-  `read_h5ad_seen()` (gated by `read_features`, i.e. not `--no-features`) opens the
-  count matrix (`counts/{probe}.filt.h5ad` preferred, else `.h5ad`) via the `hdf5`
-  crate and streams the CSR column indices in chunks to count distinct
-  features detected; per-probe counts and the cross-probe union land in
+  `read_h5ad_seen()`/`probe_features()` (compiled only under the `h5ad` cargo
+  feature, and run only when `--features` is passed) open the count matrix
+  (`counts/{probe}.filt.h5ad` preferred, else `.h5ad`) via the `hdf5` crate and
+  stream the CSR column indices in chunks to count distinct features detected;
+  per-probe counts and the cross-probe union land in
   `ProbeSummary::features_detected` and `SampleReport::features_{total,detected}`.
+  A `#[cfg(not(feature = "h5ad"))]` `probe_features` stub returns `None`, so the
+  crate compiles and the report degrades cleanly without HDF5.
 - `src/render.rs` — HTML rendering. Inlined CSS (`CSS`, a white "printout" theme),
   hand-built SVG barcode-rank plot (`knee_svg`), and section builders
   (`sample_metrics`, `cells_section`, `mapping_section`, `probe_section`,
@@ -69,12 +72,16 @@ present, and a `<sample>.cyto-report.json` machine-readable sidecar per sample
 - `cyto-cli` — `ArgsSummary`
 - `cyto-io` — `match_input_transparent` for transparent `.zst` reads
 
-## External dependencies
+## Features
 
-- `hdf5` (`hdf5-metno`) + `ndarray` for reading count-matrix `h5ad` files. This
-  links **system libhdf5** (found via `pkg-config`, e.g. `libhdf5-dev`) — building
-  cyto now requires it. Only the genes/guides-detected metrics use it; `--no-features`
-  skips the h5ad read but the link dependency remains.
+- `h5ad` (**off by default**) — enables the optional `hdf5` (`hdf5-metno`) +
+  `ndarray` dependencies for reading count-matrix `h5ad` files (genes/guides
+  detected). Enabling it links **system libhdf5** (found via `pkg-config`, e.g.
+  `libhdf5-dev`). It is off by default so the standard build, CI, and
+  cross-compiled releases need no libhdf5. Build with it via
+  `cargo install --path crates/cyto --features h5ad` (or `just install-h5ad`);
+  the `cyto` binary re-exports it as its own `h5ad` feature. At runtime the
+  metrics are additionally gated behind the `--features` flag.
 
 ## Testing
 

--- a/crates/cyto-summary/CLAUDE.md
+++ b/crates/cyto-summary/CLAUDE.md
@@ -1,0 +1,68 @@
+# cyto-summary
+
+## Purpose
+
+Generates self-contained HTML QC reports from finished cyto output directories,
+analogous in spirit to Cell Ranger's `web_summary.html` but built entirely from
+the machine-readable stat files each pipeline stage already writes. No data is
+recomputed from reads/IBUs -- the command only aggregates and renders existing
+`stats/` artifacts, so it adds negligible runtime.
+
+Invoked as `cyto summary <dir>...`. Each input may be a single sample directory
+(one containing `stats/`) or a parent directory holding several; sample dirs are
+auto-discovered. Output: one sample-prefixed `<sample>.cyto-report.html` per
+sample, a `<run>.cyto-report.html` master index when more than one sample is
+present, and a `<sample>.cyto-report.json` machine-readable sidecar per sample
+(suppressed with `--no-json`). Reports default to `<common-parent>/cyto_reports`.
+
+## Key Source Files
+
+- `src/lib.rs` — `run(&ArgsSummary)` entry point. Discovers samples, resolves the
+  output directory and run name, collects each sample, renders per-sample HTML +
+  JSON, and writes the master index. Helpers: `sanitize()` (filename-safe names),
+  `common_parent()`.
+- `src/model.rs` — Data model. `*Raw` structs (`MappingRaw`, `UnmappedRaw`,
+  `LibraryRaw`, `RunRaw`, `UmiRaw`, `AssignmentRaw`, `TimingRow`) mirror the
+  on-disk JSON/TSV stat files (deserialization targets). Report structs
+  (`SampleReport`, `ProbeSummary`, `AssignmentSummary`, `KneePoint`, `SampleKind`)
+  are the aggregated, serialized view rendered into HTML.
+- `src/collect.rs` — `collect_sample()` builds a `SampleReport` from a directory.
+  Best-effort: missing/malformed stat files degrade a panel and record a note
+  rather than failing. `discover_samples()`/`is_sample_dir()` handle input
+  expansion; `read_reads()` parses `reads.tsv.zst` (via `cyto_io::match_input_transparent`)
+  into totals, medians, and the log-spaced barcode-rank `knee_points()`;
+  `detect_kind()` classifies GEX vs CRISPR from `.done`/stats subdirs.
+- `src/render.rs` — HTML rendering. Inlined CSS (`CSS`), hand-built SVG barcode-rank
+  plot (`knee_svg`), and card builders (`mapping_card`, `probe_table`, `moi_card`,
+  `timings_card`, `libraries_card`, `notes_card`, `sample_kpis`). Entry points:
+  `render_sample()` and `render_master()`. Formatting helpers: `int`, `compact`,
+  `pct`, `f1`, `esc`, `hbar`, `kpi`, `page`.
+
+## Design Notes
+
+- **No new heavy compute**: the report is an aggregation/presentation layer over
+  existing `stats/` files. The only derived value from bulk data is the endpoint
+  sequencing saturation (`1 - UMIs/reads`) and per-barcode medians/knee, all read
+  in a single streaming pass over `reads.tsv.zst`.
+- **Self-contained output**: all CSS inlined, plots emitted as inline SVG (no JS,
+  no external assets, no plotting dependency). A report is one portable file, KB-
+  sized rather than the tens of MB a Cell Ranger `web_summary.html` embeds.
+- **Robustness**: every panel is guarded. A sample missing `stats/filtering` or a
+  malformed JSON still produces a report; issues surface in the Notes card.
+- Metrics richer than Cell Ranger where cyto has them: per-reason unmapped
+  breakdown (missing probe/feature/whitelist, failed UMI quality) and UMI
+  correction rate.
+
+## Dependencies (within workspace)
+
+- `cyto-cli` — `ArgsSummary`
+- `cyto-io` — `match_input_transparent` for transparent `.zst` reads
+
+## Testing
+
+```bash
+cargo test -p cyto-summary
+```
+
+Unit tests in `src/collect.rs` cover `median_sorted`, `saturation`, and
+`knee_points` (monotonicity, bounds, small-input passthrough).

--- a/crates/cyto-summary/CLAUDE.md
+++ b/crates/cyto-summary/CLAUDE.md
@@ -32,6 +32,11 @@ present, and a `<sample>.cyto-report.json` machine-readable sidecar per sample
   expansion; `read_reads()` parses `reads.tsv.zst` (via `cyto_io::match_input_transparent`)
   into totals, medians, and the log-spaced barcode-rank `knee_points()`;
   `detect_kind()` classifies GEX vs CRISPR from `.done`/stats subdirs.
+  `read_h5ad_seen()` (gated by `read_features`, i.e. not `--no-features`) opens the
+  count matrix (`counts/{probe}.filt.h5ad` preferred, else `.h5ad`) via the `hdf5`
+  crate and streams the CSR column indices in chunks to count distinct
+  features detected; per-probe counts and the cross-probe union land in
+  `ProbeSummary::features_detected` and `SampleReport::features_{total,detected}`.
 - `src/render.rs` — HTML rendering. Inlined CSS (`CSS`, a white "printout" theme),
   hand-built SVG barcode-rank plot (`knee_svg`), and section builders
   (`sample_metrics`, `cells_section`, `mapping_section`, `probe_section`,
@@ -63,6 +68,13 @@ present, and a `<sample>.cyto-report.json` machine-readable sidecar per sample
 
 - `cyto-cli` — `ArgsSummary`
 - `cyto-io` — `match_input_transparent` for transparent `.zst` reads
+
+## External dependencies
+
+- `hdf5` (`hdf5-metno`) + `ndarray` for reading count-matrix `h5ad` files. This
+  links **system libhdf5** (found via `pkg-config`, e.g. `libhdf5-dev`) — building
+  cyto now requires it. Only the genes/guides-detected metrics use it; `--no-features`
+  skips the h5ad read but the link dependency remains.
 
 ## Testing
 

--- a/crates/cyto-summary/Cargo.toml
+++ b/crates/cyto-summary/Cargo.toml
@@ -18,10 +18,15 @@ log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
-# HDF5 reading for feature-detection metrics (links system libhdf5).
-hdf5 = { package = "hdf5-metno", version = "0.10.1" }
-hdf5-sys = { package = "hdf5-metno-sys", version = "0.10.1" }
-ndarray = "0.16"
+# HDF5 reading for genes/guides-detected metrics. Optional and off by default:
+# enabling it links system libhdf5, which the default build (and CI /
+# cross-compiled releases) must not require.
+hdf5 = { package = "hdf5-metno", version = "0.10.1", optional = true }
+ndarray = { version = "0.16", optional = true }
+
+[features]
+# Read count matrices (h5ad) to report distinct features detected.
+h5ad = ["dep:hdf5", "dep:ndarray"]
 
 [lints]
 workspace = true

--- a/crates/cyto-summary/Cargo.toml
+++ b/crates/cyto-summary/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cyto-summary"
+version = "0.1.0"
+edition = "2024"
+license = "BSD-3-Clause"
+authors = ["Noam Teyssier <noam.teyssier@arcinstitute.org>"]
+description = "HTML QC report generation for cyto output directories"
+repository = "https://github.com/arcinstitute/cyto"
+categories = ["command-line-utilities", "science::bioinformatics"]
+keywords = ["flex", "single-cell", "qc", "report", "sequencing"]
+
+[dependencies]
+anyhow = { workspace = true }
+csv = { workspace = true }
+cyto-cli = { workspace = true }
+cyto-io = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/cyto-summary/Cargo.toml
+++ b/crates/cyto-summary/Cargo.toml
@@ -18,5 +18,10 @@ log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+# HDF5 reading for feature-detection metrics (links system libhdf5).
+hdf5 = { package = "hdf5-metno", version = "0.10.1" }
+hdf5-sys = { package = "hdf5-metno-sys", version = "0.10.1" }
+ndarray = "0.16"
+
 [lints]
 workspace = true

--- a/crates/cyto-summary/src/collect.rs
+++ b/crates/cyto-summary/src/collect.rs
@@ -1,0 +1,399 @@
+//! Collect a `SampleReport` from a finished cyto output directory.
+//!
+//! Every read is best-effort: a missing or malformed stat file degrades the
+//! corresponding panel rather than failing the whole report. Problems are
+//! recorded in `SampleReport::notes` and surfaced in the rendered output.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use cyto_io::match_input_transparent;
+use log::{debug, warn};
+use serde::de::DeserializeOwned;
+
+use crate::model::{
+    AssignmentRaw, AssignmentSummary, KneePoint, LibraryRaw, MappingRaw, ProbeSummary, RunRaw,
+    SampleKind, SampleReport, TimingRow, UmiRaw,
+};
+
+/// Return true if `path` looks like a finished cyto sample directory.
+pub fn is_sample_dir(path: &Path) -> bool {
+    path.is_dir()
+        && (path.join("stats/mapping_map.json").is_file()
+            || path.join("stats/mapping_run.json").is_file()
+            || path.join(".done").is_file())
+}
+
+/// Expand each input into concrete sample directories.
+///
+/// An input that is itself a sample directory is used directly; otherwise its
+/// immediate children are scanned. Order is preserved and duplicates removed.
+pub fn discover_samples(inputs: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let push = |p: PathBuf, out: &mut Vec<PathBuf>| {
+        let canon = p.canonicalize().unwrap_or(p);
+        if !out.contains(&canon) {
+            out.push(canon);
+        }
+    };
+
+    for input in inputs {
+        if is_sample_dir(input) {
+            push(input.clone(), &mut out);
+            continue;
+        }
+        if !input.is_dir() {
+            warn!("Skipping {} (not a directory)", input.display());
+            continue;
+        }
+        let mut children: Vec<PathBuf> = std::fs::read_dir(input)
+            .with_context(|| format!("Unable to read directory {}", input.display()))?
+            .filter_map(std::result::Result::ok)
+            .map(|e| e.path())
+            .filter(|p| is_sample_dir(p))
+            .collect();
+        children.sort();
+        if children.is_empty() {
+            warn!("No cyto sample directories found under {}", input.display());
+        }
+        for child in children {
+            push(child, &mut out);
+        }
+    }
+    Ok(out)
+}
+
+/// Read and deserialize a JSON stat file, returning `None` when it is absent.
+///
+/// A malformed file is not fatal: it logs, records a note, and yields `None`.
+fn read_json<T: DeserializeOwned>(path: &Path, notes: &mut Vec<String>) -> Option<T> {
+    if !path.is_file() {
+        return None;
+    }
+    match std::fs::File::open(path)
+        .map_err(anyhow::Error::from)
+        .and_then(|f| {
+            serde_json::from_reader::<_, T>(std::io::BufReader::new(f)).map_err(Into::into)
+        }) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            warn!("Failed to parse {}: {e}", path.display());
+            notes.push(format!("Failed to parse {}: {e}", path.display()));
+            None
+        }
+    }
+}
+
+/// Detect whether a sample is GEX or CRISPR.
+fn detect_kind(path: &Path) -> SampleKind {
+    if let Ok(done) = std::fs::read_to_string(path.join(".done")) {
+        let head = done.trim_start();
+        if head.starts_with("GexMapping") {
+            return SampleKind::Gex;
+        }
+        if head.starts_with("CrisprMapping") {
+            return SampleKind::Crispr;
+        }
+    }
+    if path.join("stats/assignments").is_dir() {
+        SampleKind::Crispr
+    } else if path.join("stats/filtering").is_dir() {
+        SampleKind::Gex
+    } else {
+        SampleKind::Unknown
+    }
+}
+
+/// Aggregates derived from a single `reads.tsv.zst` file.
+struct ReadsAgg {
+    n_barcodes: u64,
+    total_reads: u64,
+    total_umis: u64,
+    median_reads: f64,
+    median_umis: f64,
+    knee: Vec<KneePoint>,
+}
+
+fn median_sorted(sorted: &[u64]) -> f64 {
+    let n = sorted.len();
+    if n == 0 {
+        return 0.0;
+    }
+    if n % 2 == 1 {
+        sorted[n / 2] as f64
+    } else {
+        (sorted[n / 2 - 1] + sorted[n / 2]) as f64 / 2.0
+    }
+}
+
+/// Sample `n_points` log-spaced ranks from a UMI-count vector sorted descending.
+#[allow(clippy::cast_sign_loss)] // `rank` is clamped to >= 1.0 before the cast
+fn knee_points(umis_desc: &[u64], n_points: usize) -> Vec<KneePoint> {
+    let n = umis_desc.len();
+    if n == 0 || n_points == 0 {
+        return Vec::new();
+    }
+    if n <= n_points {
+        return umis_desc
+            .iter()
+            .enumerate()
+            .map(|(i, &u)| KneePoint {
+                rank: i as u64 + 1,
+                umis: u,
+            })
+            .collect();
+    }
+    let ln_n = (n as f64).ln();
+    let mut out = Vec::with_capacity(n_points);
+    let mut last: u64 = 0;
+    for i in 0..n_points {
+        let frac = i as f64 / (n_points - 1) as f64;
+        let rank = (ln_n * frac).exp().round().max(1.0) as u64;
+        let rank = rank.min(n as u64);
+        if rank == last {
+            continue;
+        }
+        last = rank;
+        out.push(KneePoint {
+            rank,
+            umis: umis_desc[rank as usize - 1],
+        });
+    }
+    out
+}
+
+/// Parse a `reads.tsv.zst` (columns: barcode, `n_umis`, `n_reads`).
+fn read_reads(path: &Path, rank_points: usize) -> Result<ReadsAgg> {
+    let handle = match_input_transparent(Some(path))?;
+    let mut rdr = csv::ReaderBuilder::new()
+        .delimiter(b'\t')
+        .has_headers(true)
+        .from_reader(handle);
+
+    let mut umis: Vec<u64> = Vec::new();
+    let mut reads: Vec<u64> = Vec::new();
+    let mut total_reads: u64 = 0;
+    let mut total_umis: u64 = 0;
+
+    let mut record = csv::StringRecord::new();
+    while rdr.read_record(&mut record)? {
+        // columns: 0 = barcode, 1 = n_umis, 2 = n_reads
+        let n_umis: u64 = record.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+        let n_reads: u64 = record.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+        total_umis += n_umis;
+        total_reads += n_reads;
+        umis.push(n_umis);
+        reads.push(n_reads);
+    }
+
+    reads.sort_unstable();
+    let median_reads = median_sorted(&reads);
+    let median_umis = {
+        let mut u = umis.clone();
+        u.sort_unstable();
+        median_sorted(&u)
+    };
+
+    umis.sort_unstable_by(|a, b| b.cmp(a));
+    let knee = knee_points(&umis, rank_points);
+
+    Ok(ReadsAgg {
+        n_barcodes: umis.len() as u64,
+        total_reads,
+        total_umis,
+        median_reads,
+        median_umis,
+        knee,
+    })
+}
+
+/// Enumerate probe basenames from `stats/reads/*.reads.tsv.zst`.
+fn probe_names(path: &Path) -> Vec<String> {
+    let reads_dir = path.join("stats/reads");
+    let mut names: Vec<String> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&reads_dir) {
+        for entry in entries.filter_map(std::result::Result::ok) {
+            let fname = entry.file_name().to_string_lossy().to_string();
+            if let Some(base) = fname.strip_suffix(".reads.tsv.zst") {
+                names.push(base.to_string());
+            }
+        }
+    }
+    names.sort();
+    names
+}
+
+fn saturation(total_reads: u64, total_umis: u64) -> Option<f64> {
+    if total_reads == 0 {
+        None
+    } else {
+        Some(1.0 - (total_umis as f64 / total_reads as f64))
+    }
+}
+
+fn assignment_summary(raw: &AssignmentRaw) -> AssignmentSummary {
+    let mut moi_distribution: Vec<(i64, u64)> = raw
+        .mois
+        .iter()
+        .copied()
+        .zip(raw.moi_counts.iter().copied())
+        .collect();
+    moi_distribution.sort_by_key(|(moi, _)| *moi);
+    let assigned_frac = if raw.n_tested == 0 {
+        0.0
+    } else {
+        raw.n_assigned as f64 / raw.n_tested as f64
+    };
+    AssignmentSummary {
+        n_tested: raw.n_tested,
+        n_assigned: raw.n_assigned,
+        n_unassigned: raw.n_unassigned,
+        assigned_frac,
+        dominant_moi: raw.dominant_moi,
+        moi_distribution,
+    }
+}
+
+/// Read one `.timings.tsv` into rows (empty on absence/failure).
+fn read_timings(path: &Path) -> Vec<TimingRow> {
+    let timings_path = path.join(".timings.tsv");
+    if !timings_path.is_file() {
+        return Vec::new();
+    }
+    match csv::ReaderBuilder::new()
+        .delimiter(b'\t')
+        .has_headers(true)
+        .from_path(&timings_path)
+    {
+        Ok(mut rdr) => rdr
+            .deserialize::<TimingRow>()
+            .filter_map(std::result::Result::ok)
+            .collect(),
+        Err(e) => {
+            warn!("Failed to read {}: {e}", timings_path.display());
+            Vec::new()
+        }
+    }
+}
+
+/// Collect all available information from a single sample directory.
+pub fn collect_sample(path: &Path, rank_points: usize) -> SampleReport {
+    debug!("Collecting sample {}", path.display());
+    let mut notes: Vec<String> = Vec::new();
+
+    let sample = path.file_name().map_or_else(
+        || path.display().to_string(),
+        |s| s.to_string_lossy().to_string(),
+    );
+    let kind = detect_kind(path);
+
+    let mapping: Option<MappingRaw> = read_json(&path.join("stats/mapping_map.json"), &mut notes);
+    let libraries: Vec<LibraryRaw> =
+        read_json(&path.join("stats/mapping_lib.json"), &mut notes).unwrap_or_default();
+    let runtime_sec = read_json::<Vec<RunRaw>>(&path.join("stats/mapping_run.json"), &mut notes)
+        .map(|runs| runs.iter().map(|r| r.elapsed_sec).sum());
+
+    let mut probes: Vec<ProbeSummary> = Vec::new();
+    for name in probe_names(path) {
+        let reads_path = path.join(format!("stats/reads/{name}.reads.tsv.zst"));
+        let agg = match read_reads(&reads_path, rank_points) {
+            Ok(agg) => agg,
+            Err(e) => {
+                warn!("Failed to read {}: {e}", reads_path.display());
+                notes.push(format!("Failed to read {}: {e}", reads_path.display()));
+                continue;
+            }
+        };
+
+        let umi_corrected_frac =
+            read_json::<UmiRaw>(&path.join(format!("stats/umi/{name}.umi.json")), &mut notes)
+                .map(|u| u.fraction_corrected);
+
+        let assignment = read_json::<AssignmentRaw>(
+            &path.join(format!("stats/assignments/{name}.json")),
+            &mut notes,
+        )
+        .map(|raw| assignment_summary(&raw));
+
+        probes.push(ProbeSummary {
+            name,
+            n_barcodes: agg.n_barcodes,
+            total_reads: agg.total_reads,
+            total_umis: agg.total_umis,
+            saturation: saturation(agg.total_reads, agg.total_umis).unwrap_or(0.0),
+            median_reads_per_barcode: agg.median_reads,
+            median_umis_per_barcode: agg.median_umis,
+            umi_corrected_frac,
+            assignment,
+            knee: agg.knee,
+        });
+    }
+
+    let total_reads: u64 = probes.iter().map(|p| p.total_reads).sum();
+    let total_umis: u64 = probes.iter().map(|p| p.total_umis).sum();
+    let overall_saturation = saturation(total_reads, total_umis);
+    let timings = read_timings(path);
+
+    if mapping.is_none() && probes.is_empty() {
+        notes.push("No mapping stats or per-probe reads found in this directory".to_string());
+    }
+
+    SampleReport {
+        sample,
+        path: path.display().to_string(),
+        kind,
+        mapping,
+        libraries,
+        runtime_sec,
+        probes,
+        timings,
+        total_reads,
+        total_umis,
+        overall_saturation,
+        notes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{knee_points, median_sorted, saturation};
+
+    #[test]
+    fn median_odd_even_empty() {
+        assert!((median_sorted(&[]) - 0.0).abs() < 1e-9);
+        assert!((median_sorted(&[5]) - 5.0).abs() < 1e-9);
+        assert!((median_sorted(&[1, 3]) - 2.0).abs() < 1e-9);
+        assert!((median_sorted(&[1, 2, 3]) - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn saturation_matches_definition() {
+        assert!(saturation(0, 0).is_none());
+        // 100 reads, 25 umis => 75% saturation
+        let s = saturation(100, 25).unwrap();
+        assert!((s - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn knee_points_are_monotone_and_bounded() {
+        let umis: Vec<u64> = (0..10_000).rev().map(|x| x as u64).collect();
+        let pts = knee_points(&umis, 50);
+        assert!(!pts.is_empty());
+        assert!(pts.len() <= 50);
+        // ranks strictly increasing, within bounds
+        for w in pts.windows(2) {
+            assert!(w[1].rank > w[0].rank);
+        }
+        assert_eq!(pts.first().unwrap().rank, 1);
+        assert!(pts.last().unwrap().rank <= umis.len() as u64);
+    }
+
+    #[test]
+    fn knee_points_small_input_returns_all() {
+        let umis = vec![9, 7, 5];
+        let pts = knee_points(&umis, 100);
+        assert_eq!(pts.len(), 3);
+        assert_eq!(pts[0].rank, 1);
+        assert_eq!(pts[0].umis, 9);
+    }
+}

--- a/crates/cyto-summary/src/collect.rs
+++ b/crates/cyto-summary/src/collect.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use cyto_io::match_input_transparent;
-use log::{debug, warn};
+use log::{debug, info, warn};
+use ndarray::s;
 use serde::de::DeserializeOwned;
 
 use crate::model::{
@@ -207,6 +208,61 @@ fn read_reads(path: &Path, rank_points: usize) -> Result<ReadsAgg> {
     })
 }
 
+/// Locate the count matrix for a probe, preferring the cell-filtered variant.
+fn h5ad_path(dir: &Path, name: &str) -> Option<PathBuf> {
+    let filt = dir.join(format!("counts/{name}.filt.h5ad"));
+    if filt.is_file() {
+        return Some(filt);
+    }
+    let raw = dir.join(format!("counts/{name}.h5ad"));
+    if raw.is_file() {
+        return Some(raw);
+    }
+    None
+}
+
+/// Read an `AnnData` (CSR) h5ad and return the panel size and a per-feature
+/// "seen" mask (feature had at least one count somewhere in the matrix).
+///
+/// Streams the sparse column indices in chunks so a multi-hundred-million-nnz
+/// matrix does not have to be held in memory at once.
+#[allow(clippy::cast_sign_loss)] // sparse column indices are non-negative
+fn read_h5ad_seen(path: &Path) -> Result<(usize, Vec<bool>)> {
+    let file = hdf5::File::open(path)?;
+    let x = file
+        .group("X")
+        .context("h5ad has no /X group (dense matrix?)")?;
+    let shape = x.attr("shape")?.read_raw::<i64>()?;
+    let n_features = usize::try_from(*shape.get(1).context("X/shape missing n_var")?)?;
+    let indices = x.dataset("indices")?;
+    let nnz = indices.shape().first().copied().unwrap_or(0);
+    let is_64 = indices.dtype().map(|d| d.size() >= 8).unwrap_or(true);
+
+    let mut seen = vec![false; n_features];
+    let chunk = 8_000_000usize;
+    let mut start = 0usize;
+    while start < nnz {
+        let end = (start + chunk).min(nnz);
+        if is_64 {
+            for &c in &indices.read_slice_1d::<i64, _>(s![start..end])? {
+                let c = c as usize;
+                if c < n_features {
+                    seen[c] = true;
+                }
+            }
+        } else {
+            for &c in &indices.read_slice_1d::<i32, _>(s![start..end])? {
+                let c = c as usize;
+                if c < n_features {
+                    seen[c] = true;
+                }
+            }
+        }
+        start = end;
+    }
+    Ok((n_features, seen))
+}
+
 /// Enumerate probe basenames from `stats/reads/*.reads.tsv.zst`.
 fn probe_names(path: &Path) -> Vec<String> {
     let reads_dir = path.join("stats/reads");
@@ -277,9 +333,12 @@ fn read_timings(path: &Path) -> Vec<TimingRow> {
 }
 
 /// Collect all available information from a single sample directory.
-pub fn collect_sample(path: &Path, rank_points: usize) -> SampleReport {
+pub fn collect_sample(path: &Path, rank_points: usize, read_features: bool) -> SampleReport {
     debug!("Collecting sample {}", path.display());
     let mut notes: Vec<String> = Vec::new();
+    // Union of per-probe "feature seen" masks, for the sample-level detected count.
+    let mut sample_seen: Option<Vec<bool>> = None;
+    let mut features_total: Option<u64> = None;
 
     let sample = path.file_name().map_or_else(
         || path.display().to_string(),
@@ -315,6 +374,33 @@ pub fn collect_sample(path: &Path, rank_points: usize) -> SampleReport {
         )
         .map(|raw| assignment_summary(&raw));
 
+        // Optional: distinct features detected, read from the count matrix.
+        let mut features_detected = None;
+        if read_features && let Some(h5) = h5ad_path(path, &name) {
+            info!("Reading features from {}", h5.display());
+            match read_h5ad_seen(&h5) {
+                Ok((n_features, seen)) => {
+                    features_detected = Some(seen.iter().filter(|&&b| b).count() as u64);
+                    features_total = Some(n_features as u64);
+                    match sample_seen.as_mut() {
+                        Some(acc) if acc.len() == seen.len() => {
+                            for (a, b) in acc.iter_mut().zip(seen.iter()) {
+                                *a |= *b;
+                            }
+                        }
+                        _ => sample_seen = Some(seen),
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to read features from {}: {e}", h5.display());
+                    notes.push(format!(
+                        "Failed to read features from {}: {e}",
+                        h5.display()
+                    ));
+                }
+            }
+        }
+
         probes.push(ProbeSummary {
             name,
             n_barcodes: agg.n_barcodes,
@@ -324,10 +410,13 @@ pub fn collect_sample(path: &Path, rank_points: usize) -> SampleReport {
             median_reads_per_barcode: agg.median_reads,
             median_umis_per_barcode: agg.median_umis,
             umi_corrected_frac,
+            features_detected,
             assignment,
             knee: agg.knee,
         });
     }
+
+    let features_detected = sample_seen.map(|s| s.iter().filter(|&&b| b).count() as u64);
 
     let total_reads: u64 = probes.iter().map(|p| p.total_reads).sum();
     let total_umis: u64 = probes.iter().map(|p| p.total_umis).sum();
@@ -350,6 +439,8 @@ pub fn collect_sample(path: &Path, rank_points: usize) -> SampleReport {
         total_reads,
         total_umis,
         overall_saturation,
+        features_total,
+        features_detected,
         notes,
     }
 }

--- a/crates/cyto-summary/src/collect.rs
+++ b/crates/cyto-summary/src/collect.rs
@@ -8,7 +8,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use cyto_io::match_input_transparent;
-use log::{debug, info, warn};
+#[cfg(feature = "h5ad")]
+use log::info;
+use log::{debug, warn};
+#[cfg(feature = "h5ad")]
 use ndarray::s;
 use serde::de::DeserializeOwned;
 
@@ -209,6 +212,7 @@ fn read_reads(path: &Path, rank_points: usize) -> Result<ReadsAgg> {
 }
 
 /// Locate the count matrix for a probe, preferring the cell-filtered variant.
+#[cfg(feature = "h5ad")]
 fn h5ad_path(dir: &Path, name: &str) -> Option<PathBuf> {
     let filt = dir.join(format!("counts/{name}.filt.h5ad"));
     if filt.is_file() {
@@ -226,6 +230,7 @@ fn h5ad_path(dir: &Path, name: &str) -> Option<PathBuf> {
 ///
 /// Streams the sparse column indices in chunks so a multi-hundred-million-nnz
 /// matrix does not have to be held in memory at once.
+#[cfg(feature = "h5ad")]
 #[allow(clippy::cast_sign_loss)] // sparse column indices are non-negative
 fn read_h5ad_seen(path: &Path) -> Result<(usize, Vec<bool>)> {
     let file = hdf5::File::open(path)?;
@@ -261,6 +266,57 @@ fn read_h5ad_seen(path: &Path) -> Result<(usize, Vec<bool>)> {
         start = end;
     }
     Ok((n_features, seen))
+}
+
+/// Read one probe's count matrix, returning the distinct features detected and
+/// folding its "seen" mask into the sample-level union.
+///
+/// Compiled out (always `None`) unless the `h5ad` feature is enabled.
+#[cfg(feature = "h5ad")]
+#[allow(clippy::cast_possible_truncation)]
+fn probe_features(
+    dir: &Path,
+    name: &str,
+    union: &mut Option<Vec<bool>>,
+    total: &mut Option<u64>,
+    notes: &mut Vec<String>,
+) -> Option<u64> {
+    let h5 = h5ad_path(dir, name)?;
+    info!("Reading features from {}", h5.display());
+    match read_h5ad_seen(&h5) {
+        Ok((n_features, seen)) => {
+            let detected = seen.iter().filter(|&&b| b).count() as u64;
+            *total = Some(n_features as u64);
+            match union.as_mut() {
+                Some(acc) if acc.len() == seen.len() => {
+                    for (a, b) in acc.iter_mut().zip(&seen) {
+                        *a |= *b;
+                    }
+                }
+                _ => *union = Some(seen),
+            }
+            Some(detected)
+        }
+        Err(e) => {
+            warn!("Failed to read features from {}: {e}", h5.display());
+            notes.push(format!(
+                "Failed to read features from {}: {e}",
+                h5.display()
+            ));
+            None
+        }
+    }
+}
+
+#[cfg(not(feature = "h5ad"))]
+fn probe_features(
+    _dir: &Path,
+    _name: &str,
+    _union: &mut Option<Vec<bool>>,
+    _total: &mut Option<u64>,
+    _notes: &mut Vec<String>,
+) -> Option<u64> {
+    None
 }
 
 /// Enumerate probe basenames from `stats/reads/*.reads.tsv.zst`.
@@ -374,32 +430,19 @@ pub fn collect_sample(path: &Path, rank_points: usize, read_features: bool) -> S
         )
         .map(|raw| assignment_summary(&raw));
 
-        // Optional: distinct features detected, read from the count matrix.
-        let mut features_detected = None;
-        if read_features && let Some(h5) = h5ad_path(path, &name) {
-            info!("Reading features from {}", h5.display());
-            match read_h5ad_seen(&h5) {
-                Ok((n_features, seen)) => {
-                    features_detected = Some(seen.iter().filter(|&&b| b).count() as u64);
-                    features_total = Some(n_features as u64);
-                    match sample_seen.as_mut() {
-                        Some(acc) if acc.len() == seen.len() => {
-                            for (a, b) in acc.iter_mut().zip(seen.iter()) {
-                                *a |= *b;
-                            }
-                        }
-                        _ => sample_seen = Some(seen),
-                    }
-                }
-                Err(e) => {
-                    warn!("Failed to read features from {}: {e}", h5.display());
-                    notes.push(format!(
-                        "Failed to read features from {}: {e}",
-                        h5.display()
-                    ));
-                }
-            }
-        }
+        // Optional: distinct features detected, read from the count matrix
+        // (only when built with the `h5ad` feature and requested at runtime).
+        let features_detected = if read_features {
+            probe_features(
+                path,
+                &name,
+                &mut sample_seen,
+                &mut features_total,
+                &mut notes,
+            )
+        } else {
+            None
+        };
 
         probes.push(ProbeSummary {
             name,

--- a/crates/cyto-summary/src/lib.rs
+++ b/crates/cyto-summary/src/lib.rs
@@ -1,0 +1,124 @@
+//! HTML QC report generation for finished cyto output directories.
+//!
+//! `cyto summary <dir>...` discovers sample directories, aggregates the per-stage
+//! stat files each already wrote (`stats/mapping_*.json`, `stats/reads/*.zst`,
+//! `stats/umi/*.json`, `stats/assignments/*.json`, `.timings.tsv`), and renders a
+//! self-contained, sample-prefixed HTML report per sample -- plus a master index
+//! when several samples are present -- alongside machine-readable JSON sidecars.
+//!
+//! Collection is best-effort: missing stat files degrade individual panels
+//! rather than failing the report (see [`collect`]).
+
+mod collect;
+mod model;
+mod render;
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use cyto_cli::ArgsSummary;
+use log::info;
+
+pub use model::SampleReport;
+
+/// Sanitize a string for use as a filename component.
+fn sanitize(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// The shared parent directory of all samples, when they have one.
+fn common_parent(samples: &[PathBuf]) -> Option<PathBuf> {
+    let mut parents = samples.iter().filter_map(|p| p.parent());
+    let first = parents.next()?;
+    if parents.all(|p| p == first) {
+        Some(first.to_path_buf())
+    } else {
+        None
+    }
+}
+
+/// Entry point for `cyto summary`.
+pub fn run(args: &ArgsSummary) -> Result<()> {
+    let samples = collect::discover_samples(&args.inputs)?;
+    if samples.is_empty() {
+        bail!(
+            "No cyto sample directories found in the provided input(s). \
+             Point at a finished output directory (containing `stats/`) or a parent of several."
+        );
+    }
+    info!("Found {} sample director(y/ies)", samples.len());
+
+    let parent = common_parent(&samples);
+    let outdir = args.outdir.clone().unwrap_or_else(|| {
+        parent
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("cyto_reports")
+    });
+    std::fs::create_dir_all(&outdir)
+        .with_context(|| format!("Unable to create report directory {}", outdir.display()))?;
+
+    let run_name = args.run_name.clone().unwrap_or_else(|| {
+        parent.as_ref().and_then(|p| p.file_name()).map_or_else(
+            || "cyto_run".to_string(),
+            |s| s.to_string_lossy().to_string(),
+        )
+    });
+
+    let mut reports: Vec<(SampleReport, String)> = Vec::new();
+    for sample_dir in &samples {
+        let report = collect::collect_sample(sample_dir, args.rank_points);
+        let stem = sanitize(&report.sample);
+        let html_name = format!("{stem}.cyto-report.html");
+        write_string(&outdir.join(&html_name), &render::render_sample(&report))?;
+        if !args.no_json {
+            write_json(&outdir.join(format!("{stem}.cyto-report.json")), &report)?;
+        }
+        info!("Wrote report for '{}' -> {}", report.sample, html_name);
+        reports.push((report, html_name));
+    }
+
+    if reports.is_empty() {
+        bail!("No reports could be generated from the provided input(s)");
+    }
+
+    if reports.len() > 1 && !args.no_master {
+        let refs: Vec<(&SampleReport, String)> =
+            reports.iter().map(|(r, h)| (r, h.clone())).collect();
+        let master_name = format!("{}.cyto-report.html", sanitize(&run_name));
+        write_string(
+            &outdir.join(&master_name),
+            &render::render_master(&run_name, &refs),
+        )?;
+        info!("Wrote master report -> {master_name}");
+        println!("{}", outdir.join(&master_name).display());
+    } else {
+        println!("{}", outdir.join(&reports[0].1).display());
+    }
+
+    info!(
+        "Done. {} report(s) written to {}",
+        reports.len(),
+        outdir.display()
+    );
+    Ok(())
+}
+
+fn write_string(path: &Path, contents: &str) -> Result<()> {
+    std::fs::write(path, contents).with_context(|| format!("Unable to write {}", path.display()))
+}
+
+fn write_json(path: &Path, report: &SampleReport) -> Result<()> {
+    let file = std::fs::File::create(path)
+        .with_context(|| format!("Unable to create {}", path.display()))?;
+    serde_json::to_writer_pretty(std::io::BufWriter::new(file), report)?;
+    Ok(())
+}

--- a/crates/cyto-summary/src/lib.rs
+++ b/crates/cyto-summary/src/lib.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use cyto_cli::ArgsSummary;
-use log::info;
+use log::{info, warn};
 
 pub use model::SampleReport;
 
@@ -56,6 +56,13 @@ pub fn run(args: &ArgsSummary) -> Result<()> {
     }
     info!("Found {} sample director(y/ies)", samples.len());
 
+    if args.features && !cfg!(feature = "h5ad") {
+        warn!(
+            "--features was requested but this build has no `h5ad` support; \
+             genes/guides-detected metrics will be omitted (rebuild with --features h5ad)"
+        );
+    }
+
     let parent = common_parent(&samples);
     let outdir = args.outdir.clone().unwrap_or_else(|| {
         parent
@@ -75,7 +82,7 @@ pub fn run(args: &ArgsSummary) -> Result<()> {
 
     let mut reports: Vec<(SampleReport, String)> = Vec::new();
     for sample_dir in &samples {
-        let report = collect::collect_sample(sample_dir, args.rank_points, !args.no_features);
+        let report = collect::collect_sample(sample_dir, args.rank_points, args.features);
         let stem = sanitize(&report.sample);
         let html_name = format!("{stem}.cyto-report.html");
         write_string(&outdir.join(&html_name), &render::render_sample(&report))?;

--- a/crates/cyto-summary/src/lib.rs
+++ b/crates/cyto-summary/src/lib.rs
@@ -75,7 +75,7 @@ pub fn run(args: &ArgsSummary) -> Result<()> {
 
     let mut reports: Vec<(SampleReport, String)> = Vec::new();
     for sample_dir in &samples {
-        let report = collect::collect_sample(sample_dir, args.rank_points);
+        let report = collect::collect_sample(sample_dir, args.rank_points, !args.no_features);
         let stem = sanitize(&report.sample);
         let html_name = format!("{stem}.cyto-report.html");
         write_string(&outdir.join(&html_name), &render::render_sample(&report))?;

--- a/crates/cyto-summary/src/model.rs
+++ b/crates/cyto-summary/src/model.rs
@@ -136,6 +136,8 @@ pub struct ProbeSummary {
     pub median_reads_per_barcode: f64,
     pub median_umis_per_barcode: f64,
     pub umi_corrected_frac: Option<f64>,
+    /// Distinct features (genes/guides) with at least one count in this probe's matrix.
+    pub features_detected: Option<u64>,
     pub assignment: Option<AssignmentSummary>,
     /// Downsampled points for the barcode-rank plot (not present when reads are absent).
     pub knee: Vec<KneePoint>,
@@ -158,6 +160,10 @@ pub struct SampleReport {
     pub total_umis: u64,
     /// Aggregate saturation across probes (`1 - total_umis / total_reads`).
     pub overall_saturation: Option<f64>,
+    /// Total features (genes/guides) in the count matrix panel.
+    pub features_total: Option<u64>,
+    /// Distinct features detected across all probes (union).
+    pub features_detected: Option<u64>,
     /// Non-fatal issues encountered while collecting (missing/failed files).
     pub notes: Vec<String>,
 }

--- a/crates/cyto-summary/src/model.rs
+++ b/crates/cyto-summary/src/model.rs
@@ -1,0 +1,163 @@
+//! Data model for cyto QC reports.
+//!
+//! Two families of structs live here:
+//! - `*Raw` types mirror the on-disk JSON stat files (deserialization targets).
+//! - The report types (`SampleReport`, `ProbeSummary`, ...) are the aggregated,
+//!   serialized-to-sidecar view rendered into HTML.
+
+use serde::{Deserialize, Serialize};
+
+/// Mirror of `stats/mapping_map.json` (`cyto-map` `MappingStatistics`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MappingRaw {
+    pub total_reads: u64,
+    pub mapped_reads: u64,
+    pub unmapped_reads: u64,
+    pub mapped_reads_frac: f64,
+    pub unmapped_reads_frac: f64,
+    pub unmapped: UnmappedRaw,
+}
+
+/// Mirror of the `unmapped` block of `stats/mapping_map.json`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UnmappedRaw {
+    pub missing_probe: u64,
+    pub missing_feature: u64,
+    pub missing_whitelist: u64,
+    pub failed_umi_qual: u64,
+    pub umi_truncated: u64,
+    pub missing_probe_frac: f64,
+    pub missing_feature_frac: f64,
+    pub missing_whitelist_frac: f64,
+    pub failed_umi_qual_frac: f64,
+    pub umi_truncated_frac: f64,
+}
+
+/// Mirror of a `stats/mapping_lib.json` entry (`cyto-map` `LibraryStatistics`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LibraryRaw {
+    pub name: String,
+    pub total_elem: u64,
+    pub total_aggr: u64,
+    pub total_hash: u64,
+    pub position: u64,
+    pub mate: String,
+    pub window: u64,
+    pub exact: bool,
+    pub init_time: f64,
+}
+
+/// Mirror of a `stats/mapping_run.json` entry (`cyto-map` `InputRuntimeStatistics`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct RunRaw {
+    #[allow(dead_code)]
+    pub input_id: u64,
+    pub elapsed_sec: f64,
+}
+
+/// Mirror of `stats/umi/{probe}.umi.json` (`cyto-ibu-umi-correct` `Statistics`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct UmiRaw {
+    #[allow(dead_code)]
+    pub total: u64,
+    #[allow(dead_code)]
+    pub corrected: u64,
+    pub fraction_corrected: f64,
+}
+
+/// Mirror of `stats/assignments/{probe}.json` (`geomux --stats`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct AssignmentRaw {
+    #[allow(dead_code)]
+    pub n_untested: u64,
+    pub n_tested: u64,
+    pub n_assigned: u64,
+    pub n_unassigned: u64,
+    pub dominant_moi: i64,
+    pub mois: Vec<i64>,
+    pub moi_counts: Vec<u64>,
+}
+
+/// A single row of `.timings.tsv`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TimingRow {
+    pub ibu_name: String,
+    pub module: String,
+    pub elapsed: f64,
+}
+
+/// The kind of library a sample directory holds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SampleKind {
+    Gex,
+    Crispr,
+    Unknown,
+}
+
+impl SampleKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            SampleKind::Gex => "Gene Expression",
+            SampleKind::Crispr => "CRISPR Guide",
+            SampleKind::Unknown => "Unknown",
+        }
+    }
+}
+
+/// A single (rank, umis) sample used to draw the barcode-rank knee plot.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct KneePoint {
+    pub rank: u64,
+    pub umis: u64,
+}
+
+/// Guide-assignment summary for a CRISPR probe.
+#[derive(Debug, Clone, Serialize)]
+pub struct AssignmentSummary {
+    pub n_tested: u64,
+    pub n_assigned: u64,
+    pub n_unassigned: u64,
+    pub assigned_frac: f64,
+    pub dominant_moi: i64,
+    /// (moi, count) pairs, ascending by moi.
+    pub moi_distribution: Vec<(i64, u64)>,
+}
+
+/// Per-probe (per demultiplexed barcode) summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProbeSummary {
+    pub name: String,
+    pub n_barcodes: u64,
+    pub total_reads: u64,
+    pub total_umis: u64,
+    /// Sequencing saturation endpoint: `1 - total_umis / total_reads`.
+    pub saturation: f64,
+    pub median_reads_per_barcode: f64,
+    pub median_umis_per_barcode: f64,
+    pub umi_corrected_frac: Option<f64>,
+    pub assignment: Option<AssignmentSummary>,
+    /// Downsampled points for the barcode-rank plot (not present when reads are absent).
+    pub knee: Vec<KneePoint>,
+}
+
+/// Everything known about one sample directory.
+#[derive(Debug, Clone, Serialize)]
+pub struct SampleReport {
+    pub sample: String,
+    pub path: String,
+    pub kind: SampleKind,
+    pub mapping: Option<MappingRaw>,
+    pub libraries: Vec<LibraryRaw>,
+    pub runtime_sec: Option<f64>,
+    pub probes: Vec<ProbeSummary>,
+    pub timings: Vec<TimingRow>,
+    /// Sum of `total_reads` across probes.
+    pub total_reads: u64,
+    /// Sum of `total_umis` across probes.
+    pub total_umis: u64,
+    /// Aggregate saturation across probes (`1 - total_umis / total_reads`).
+    pub overall_saturation: Option<f64>,
+    /// Non-fatal issues encountered while collecting (missing/failed files).
+    pub notes: Vec<String>,
+}

--- a/crates/cyto-summary/src/render.rs
+++ b/crates/cyto-summary/src/render.rs
@@ -85,6 +85,12 @@ table.data tbody tr:hover td{background:var(--hover)}
   font-size:12px;color:var(--muted);text-align:right}
 .subhead{font-size:11px;letter-spacing:.05em;text-transform:uppercase;color:var(--faint);margin:16px 0 8px}
 @media(max-width:780px){.bar{grid-template-columns:130px 1fr 120px;gap:10px}}
+.bars2{display:grid;grid-template-columns:1fr 1fr;gap:0 48px}
+.bars2 .bar{grid-template-columns:150px 1fr 122px;gap:12px}
+@media(max-width:780px){.bars2{grid-template-columns:1fr}}
+.cols2{display:grid;grid-template-columns:1fr 1fr;gap:20px 44px;align-items:start}
+.cols2 .section{margin-top:0}
+@media(max-width:780px){.cols2{grid-template-columns:1fr}}
 
 figure{margin:0}
 figcaption{color:var(--muted);font-size:11.5px;margin-top:10px}
@@ -376,6 +382,20 @@ fn cells_section(r: &SampleReport) -> String {
         "<tr><td>Total UMIs</td><td>{}</td></tr>",
         int(r.total_umis)
     );
+    if barcodes > 0 {
+        let _ = write!(
+            keys,
+            "<tr><td>Mean UMIs / barcode</td><td>{}</td></tr>",
+            int(r.total_umis / barcodes)
+        );
+    }
+    if r.total_umis > 0 {
+        let _ = write!(
+            keys,
+            "<tr><td>Reads per UMI</td><td>{}</td></tr>",
+            f1(r.total_reads as f64 / r.total_umis as f64)
+        );
+    }
     if let Some(s) = r.overall_saturation {
         let _ = write!(
             keys,
@@ -384,11 +404,6 @@ fn cells_section(r: &SampleReport) -> String {
         );
     }
     if let Some(mp) = &r.mapping {
-        let _ = write!(
-            keys,
-            "<tr><td>Reads in library</td><td>{}</td></tr>",
-            int(mp.total_reads)
-        );
         let _ = write!(
             keys,
             "<tr><td>Reads mapped</td><td>{}</td></tr>",
@@ -438,7 +453,7 @@ fn mapping_section(r: &SampleReport) -> String {
         }
         reasons.push_str(&bar(
             label,
-            &format!("{} · {} of unmapped", int(count), pct(frac)),
+            &format!("{} · {}", compact(count), pct(frac)),
             frac,
             "var(--faint)",
         ));
@@ -446,7 +461,7 @@ fn mapping_section(r: &SampleReport) -> String {
     if !reasons.is_empty() {
         let _ = write!(
             bars,
-            "<div class=\"subhead\">Unmapped reads by reason</div>{reasons}"
+            "<div class=\"subhead\">Unmapped reads by reason</div><div class=\"bars2\">{reasons}</div>"
         );
     }
     format!(
@@ -532,19 +547,32 @@ fn moi_section(r: &SampleReport) -> String {
     let max = agg.values().copied().max().unwrap_or(1).max(1) as f64;
     let total: u64 = agg.values().copied().sum();
     let mut rows = String::new();
-    for (moi, count) in agg.iter().take(15) {
-        let frac_total = *count as f64 / total as f64;
+    let mut tail: u64 = 0;
+    for (moi, count) in &agg {
+        if *moi <= 8 {
+            let frac_total = *count as f64 / total as f64;
+            rows.push_str(&bar(
+                &format!("{moi} guide(s)"),
+                &format!("{} · {}", int(*count), pct(frac_total)),
+                *count as f64 / max,
+                "var(--accent)",
+            ));
+        } else {
+            tail += *count;
+        }
+    }
+    if tail > 0 {
         rows.push_str(&bar(
-            &format!("{moi} guide(s)"),
-            &format!("{} · {}", int(*count), pct(frac_total)),
-            *count as f64 / max,
+            "9+ guides",
+            &format!("{} · {}", int(tail), pct(tail as f64 / total as f64)),
+            tail as f64 / max,
             "var(--accent)",
         ));
     }
     format!(
         "<section class=\"section\">{}\
          <div class=\"hint\">Assigned cells by guides-per-cell, across all probes ({} cells).</div>\
-         <div class=\"bars\">{rows}</div></section>",
+         <div class=\"bars bars2\">{rows}</div></section>",
         eyebrow("Guide multiplicity"),
         int(total),
     )
@@ -595,17 +623,23 @@ fn timing_section(r: &SampleReport) -> String {
     format!(
         "<section class=\"section\">{}\
          <div class=\"hint\">Wall-clock summed per module; post-mapping steps run in parallel across probes.</div>\
-         <div class=\"bars\">{rows}</div></section>",
+         <div class=\"bars bars2\">{rows}</div></section>",
         eyebrow("Pipeline timing"),
     )
 }
 
 fn library_section(r: &SampleReport) -> String {
-    if r.libraries.is_empty() {
+    // The cell-barcode whitelist is not a feature library; hide it here.
+    let libs: Vec<_> = r
+        .libraries
+        .iter()
+        .filter(|l| l.name != "whitelist")
+        .collect();
+    if libs.is_empty() {
         return String::new();
     }
     let mut body = String::new();
-    for l in &r.libraries {
+    for l in libs {
         let _ = write!(
             body,
             "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
@@ -674,6 +708,54 @@ pub fn render_sample(r: &SampleReport) -> String {
 // master (cross-sample) report
 // ---------------------------------------------------------------------------
 
+/// Render one master column: a linked sample table for a single library type.
+fn master_column(title: &str, subset: &[&(&SampleReport, String)], is_crispr: bool) -> String {
+    let mut rows = String::new();
+    for (r, href) in subset {
+        let mapped = r
+            .mapping
+            .as_ref()
+            .map_or_else(|| "&mdash;".to_string(), |m| pct(m.mapped_reads_frac));
+        let sat = r
+            .overall_saturation
+            .map_or_else(|| "&mdash;".to_string(), pct);
+        let reads = r.mapping.as_ref().map_or(r.total_reads, |m| m.total_reads);
+        let _ = write!(
+            rows,
+            "<tr><td><a href=\"{}\">{}</a></td><td>{}</td><td>{}</td><td>{}</td><td>{}</td>",
+            esc(href),
+            esc(&r.sample),
+            compact(reads),
+            mapped,
+            compact(r.total_umis),
+            sat,
+        );
+        if is_crispr {
+            let assigned: u64 = r
+                .probes
+                .iter()
+                .filter_map(|p| p.assignment.as_ref().map(|a| a.n_assigned))
+                .sum();
+            let cells = if assigned > 0 {
+                compact(assigned)
+            } else {
+                "&mdash;".to_string()
+            };
+            let _ = write!(rows, "<td>{cells}</td>");
+        }
+        rows.push_str("</tr>");
+    }
+    let head = if is_crispr {
+        "<tr><th>Sample</th><th>Reads</th><th>Mapped</th><th>UMIs</th><th>Sat.</th><th>Cells</th></tr>"
+    } else {
+        "<tr><th>Sample</th><th>Reads</th><th>Mapped</th><th>UMIs</th><th>Sat.</th></tr>"
+    };
+    format!(
+        "<section class=\"section\">{}<div class=\"overflow\"><table class=\"data\"><thead>{head}</thead><tbody>{rows}</tbody></table></div></section>",
+        eyebrow(title),
+    )
+}
+
 /// Render an index over multiple samples, linking to each per-sample report.
 pub fn render_master(run_name: &str, reports: &[(&SampleReport, String)]) -> String {
     let n = reports.len();
@@ -689,46 +771,25 @@ pub fn render_master(run_name: &str, reports: &[(&SampleReport, String)]) -> Str
     m.push_str(&metric(&compact(total_umis), "UMIs"));
     let metrics = format!("<div class=\"metrics\">{m}</div>");
 
-    let mut body_rows = String::new();
-    for (r, href) in reports {
-        let mapped = r
-            .mapping
-            .as_ref()
-            .map_or_else(|| "&mdash;".to_string(), |m| pct(m.mapped_reads_frac));
-        let sat = r
-            .overall_saturation
-            .map_or_else(|| "&mdash;".to_string(), pct);
-        let reads = r.mapping.as_ref().map_or(r.total_reads, |m| m.total_reads);
-        let assigned: u64 = r
-            .probes
-            .iter()
-            .filter_map(|p| p.assignment.as_ref().map(|a| a.n_assigned))
-            .sum();
-        let cells = if r.kind == SampleKind::Crispr && assigned > 0 {
-            int(assigned)
-        } else {
-            "&mdash;".to_string()
-        };
-        let _ = write!(
-            body_rows,
-            "<tr><td><a href=\"{}\">{}</a></td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
-            esc(href),
-            esc(&r.sample),
-            esc(r.kind.label()),
-            int(reads),
-            mapped,
-            r.probes.len(),
-            int(r.total_umis),
-            sat,
-            cells,
-        );
+    // Split samples into separate columns by library type.
+    let kinds = [
+        (SampleKind::Gex, "Gene expression", false),
+        (SampleKind::Crispr, "CRISPR", true),
+        (SampleKind::Unknown, "Other", false),
+    ];
+    let mut columns = String::new();
+    let mut n_cols = 0;
+    for (kind, title, is_crispr) in kinds {
+        let subset: Vec<&(&SampleReport, String)> =
+            reports.iter().filter(|(r, _)| r.kind == kind).collect();
+        if subset.is_empty() {
+            continue;
+        }
+        n_cols += 1;
+        columns.push_str(&master_column(title, &subset, is_crispr));
     }
-    let table = format!(
-        "<section class=\"section\">{}<div class=\"overflow\"><table class=\"data\"><thead>\
-         <tr><th>Sample</th><th>Type</th><th>Reads</th><th>Mapped</th><th>Probes</th><th>UMIs</th><th>Saturation</th><th>Cells assigned</th></tr>\
-         </thead><tbody>{body_rows}</tbody></table></div></section>",
-        eyebrow("Samples"),
-    );
+    let grid = if n_cols > 1 { "cols2" } else { "" };
+    let body_grid = format!("<div class=\"{grid}\">{columns}</div>");
 
     let header = format!(
         "<div class=\"masthead\"><div><h1 class=\"title\">{}<span class=\"kind\">run</span></h1>\
@@ -739,6 +800,6 @@ pub fn render_master(run_name: &str, reports: &[(&SampleReport, String)]) -> Str
     );
     page(
         &format!("{run_name} — cyto run report"),
-        &format!("{header}{metrics}{table}{}", footer(run_name)),
+        &format!("{header}{metrics}{body_grid}{}", footer(run_name)),
     )
 }

--- a/crates/cyto-summary/src/render.rs
+++ b/crates/cyto-summary/src/render.rs
@@ -729,16 +729,13 @@ fn alerts(r: &SampleReport) -> String {
 
 /// Render a full per-sample HTML report.
 pub fn render_sample(r: &SampleReport) -> String {
-    let meta = {
-        let mut m = esc(&r.path);
-        if let Some(s) = r.runtime_sec {
-            let _ = write!(m, "  ·  mapping {}", fmt_dur(s));
-        }
-        m
-    };
+    // Keep the masthead clean; the full path lives in the footer.
+    let sub = r
+        .runtime_sec
+        .map(|s| format!("<div class=\"sub\">mapping {}</div>", fmt_dur(s)))
+        .unwrap_or_default();
     let header = format!(
-        "<div class=\"masthead\"><div><h1 class=\"title\">{}<span class=\"kind\">{}</span></h1>\
-         <div class=\"sub\">{meta}</div></div>\
+        "<div class=\"masthead\"><div><h1 class=\"title\">{}<span class=\"kind\">{}</span></h1>{sub}</div>\
          <div class=\"brand\"><b>cyto</b>QC report</div></div>",
         esc(&r.sample),
         esc(r.kind.label()),

--- a/crates/cyto-summary/src/render.rs
+++ b/crates/cyto-summary/src/render.rs
@@ -1,53 +1,101 @@
 //! Render `SampleReport`s into self-contained HTML.
 //!
-//! No external assets: all CSS is inlined and plots are hand-built SVG, so a
-//! report is a single portable file. Two entry points: [`render_sample`] for a
-//! per-sample report and [`render_master`] for the cross-sample index.
+//! Design: a white "sequencing QC printout" -- flat paper, hairline rules
+//! instead of filled cards, all numeric data set in tabular monospace, a single
+//! restrained accent. Layout follows the flow single-cell users know from
+//! Cell Ranger (headline metrics, then a metrics-left / barcode-rank-plot-right
+//! block, then mapping and per-probe detail) without copying its styling.
+//!
+//! No external assets: CSS is inlined and plots are hand-built SVG, so a report
+//! is a single portable file. Entry points: [`render_sample`] and
+//! [`render_master`].
 
 use std::fmt::Write as _;
 
 use crate::model::{ProbeSummary, SampleKind, SampleReport};
 
-const PALETTE: [&str; 10] = [
-    "#2563eb", "#dc2626", "#059669", "#d97706", "#7c3aed", "#0891b2", "#db2777", "#65a30d",
-    "#9333ea", "#0d9488",
+/// Muted, print-leaning categorical palette for barcode-rank lines.
+const PALETTE: [&str; 8] = [
+    "#0b6a83", "#b4531f", "#3b6b35", "#7a4fa3", "#9c2f4a", "#2f5f8a", "#8a6d1f", "#496b6b",
 ];
 
 const CSS: &str = r#"
-:root{--bg:#f6f7f9;--card:#fff;--ink:#1a1d21;--muted:#6b7280;--line:#e5e7eb;--accent:#2563eb;--good:#059669;--warn:#d97706;--bad:#dc2626;--track:#eef0f3}
-@media (prefers-color-scheme:dark){:root{--bg:#0f1216;--card:#171b21;--ink:#e6e9ee;--muted:#9aa4b2;--line:#262c35;--accent:#60a5fa;--track:#20262e}}
+:root{
+  --paper:#ffffff;--ink:#14181c;--muted:#727a82;--faint:#9aa1a8;
+  --rule:#e7e9ec;--rule-strong:#d2d6da;--accent:#0b6a83;
+  --good:#2f6b3a;--warn:#9a6a15;--bad:#a23b3b;--track:#f1f2f4;--hover:#fafbfc;
+}
 *{box-sizing:border-box}
-body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
-.wrap{max-width:960px;margin:0 auto;padding:28px 20px 64px}
-h1{font-size:22px;margin:0 0 2px}
-h2{font-size:15px;margin:0 0 14px;font-weight:600}
-a{color:var(--accent);text-decoration:none}
-a:hover{text-decoration:underline}
-.muted{color:var(--muted)}
-.mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px}
-.top{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin-bottom:20px}
-.badge{display:inline-block;padding:2px 9px;border-radius:999px;font-size:12px;font-weight:600;background:var(--accent);color:#fff}
-.badge.gex{background:#2563eb}.badge.crispr{background:#7c3aed}.badge.unknown{background:#6b7280}
-.card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin-bottom:16px}
-.kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-bottom:16px}
-.kpi{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
-.kpi .num{font-size:22px;font-weight:700;letter-spacing:-.02em}
-.kpi .lbl{font-size:12px;color:var(--muted);margin-top:2px}
-table{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}
-th,td{text-align:right;padding:7px 10px;border-bottom:1px solid var(--line);white-space:nowrap}
-th:first-child,td:first-child{text-align:left}
-th{font-size:12px;color:var(--muted);font-weight:600}
-tbody tr:last-child td{border-bottom:none}
+html{-webkit-text-size-adjust:100%}
+body{margin:0;background:var(--paper);color:var(--ink);
+  font:14px/1.55 "Helvetica Neue",Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+.page{max-width:1060px;margin:0 auto;padding:44px 32px 72px}
+.mono{font-family:ui-monospace,"SF Mono","JetBrains Mono",Menlo,Consolas,monospace;font-variant-numeric:tabular-nums}
+a{color:var(--accent);text-decoration:none;border-bottom:1px solid rgba(11,106,131,.32)}
+a:hover{border-bottom-color:var(--accent)}
+
+.masthead{display:flex;justify-content:space-between;align-items:flex-end;gap:20px;
+  padding-bottom:14px;border-bottom:2px solid var(--ink)}
+.title{font-size:30px;font-weight:700;letter-spacing:-.02em;line-height:1.04;margin:0}
+.kind{margin-left:12px;font-size:11px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--accent)}
+.sub{color:var(--muted);font-size:12.5px;margin-top:7px;font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace}
+.brand{text-align:right;color:var(--faint);font-size:11.5px;white-space:nowrap;line-height:1.5}
+.brand b{display:block;color:var(--ink);font-weight:700;letter-spacing:.14em;text-transform:uppercase;font-size:12px}
+
+.metrics{display:flex;flex-wrap:wrap;margin:30px 0 4px;
+  border-top:1px solid var(--rule);border-bottom:1px solid var(--rule)}
+.metric{flex:1 1 0;min-width:132px;padding:16px 20px 15px;border-left:1px solid var(--rule)}
+.metric:first-child{border-left:none;padding-left:0}
+.metric .v{font-size:23px;font-weight:600;letter-spacing:-.01em;
+  font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;font-variant-numeric:tabular-nums}
+.metric .k{margin-top:4px;font-size:10.5px;letter-spacing:.07em;text-transform:uppercase;color:var(--muted)}
+
+.section{margin-top:40px}
+.eyebrow{display:flex;align-items:center;gap:14px;margin-bottom:16px}
+.eyebrow h2{font-size:12px;font-weight:700;letter-spacing:.11em;text-transform:uppercase;margin:0}
+.eyebrow .ln{flex:1;height:1px;background:var(--rule-strong)}
+.hint{color:var(--muted);font-size:12px;margin:-6px 0 16px;max-width:70ch}
+
+.split{display:grid;grid-template-columns:minmax(0,320px) minmax(0,1fr);gap:36px;align-items:start}
+@media(max-width:780px){.split{grid-template-columns:1fr;gap:24px}}
+
+.keys{width:100%;border-collapse:collapse}
+.keys td{padding:8px 0;border-bottom:1px solid var(--rule);font-size:13px;color:var(--muted)}
+.keys td:last-child{text-align:right;color:var(--ink);
+  font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;font-variant-numeric:tabular-nums}
+.keys tr:last-child td{border-bottom:none}
+
+table.data{width:100%;border-collapse:collapse}
+table.data th,table.data td{padding:9px 14px;white-space:nowrap;font-size:13px}
+table.data th{font-size:10.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--muted);
+  font-weight:700;text-align:right;border-bottom:1px solid var(--rule-strong)}
+table.data td{text-align:right;border-bottom:1px solid var(--rule)}
+table.data th:first-child,table.data td:first-child{text-align:left}
+table.data td:not(:first-child){font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;font-variant-numeric:tabular-nums}
+table.data tbody tr:last-child td{border-bottom:none}
+table.data tbody tr:hover td{background:var(--hover)}
 .overflow{overflow-x:auto}
-.bar-row{display:flex;align-items:center;gap:10px;margin:6px 0}
-.bar-label{width:170px;flex:none;font-size:13px}
-.bar-track{flex:1;height:14px;background:var(--track);border-radius:7px;overflow:hidden}
-.bar-fill{height:100%;border-radius:7px}
-.bar-val{width:150px;flex:none;text-align:right;font-size:12px;font-variant-numeric:tabular-nums;color:var(--muted)}
-.plot{width:100%;height:auto;overflow:visible}
-.note{color:var(--warn);font-size:13px;margin:3px 0}
-.foot{color:var(--muted);font-size:12px;margin-top:8px;text-align:center}
-.hint{font-size:12px;color:var(--muted);margin:-6px 0 12px}
+
+.bars{margin-top:2px}
+.bar{display:grid;grid-template-columns:200px 1fr 168px;align-items:center;gap:16px;padding:5px 0}
+.bar .lbl{font-size:13px}
+.bar .track{height:7px;background:var(--track)}
+.bar .fill{height:100%}
+.bar .val{font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;font-variant-numeric:tabular-nums;
+  font-size:12px;color:var(--muted);text-align:right}
+.subhead{font-size:11px;letter-spacing:.05em;text-transform:uppercase;color:var(--faint);margin:16px 0 8px}
+@media(max-width:780px){.bar{grid-template-columns:130px 1fr 120px;gap:10px}}
+
+figure{margin:0}
+figcaption{color:var(--muted);font-size:11.5px;margin-top:10px}
+svg.plot{display:block;width:100%;height:auto}
+
+.alert{border:1px solid var(--rule);border-left:3px solid var(--warn);
+  padding:11px 15px;margin:22px 0 0;font-size:13px;color:#4a4f55}
+.alert b{color:var(--warn);font-weight:700}
+
+.foot{margin-top:60px;padding-top:16px;border-top:1px solid var(--rule);
+  color:var(--faint);font-size:11.5px;display:flex;justify-content:space-between;gap:16px}
 "#;
 
 // ---------------------------------------------------------------------------
@@ -76,7 +124,7 @@ fn int(n: u64) -> String {
     out
 }
 
-/// Compact magnitude (e.g. `10.72B`) for headline tiles.
+/// Compact magnitude (e.g. `10.72B`) for headline figures.
 fn compact(n: u64) -> String {
     let f = n as f64;
     if f >= 1e9 {
@@ -98,20 +146,27 @@ fn f1(x: f64) -> String {
     format!("{x:.1}")
 }
 
-fn kpi(num: &str, lbl: &str) -> String {
+fn metric(v: &str, k: &str) -> String {
     format!(
-        "<div class=\"kpi\"><div class=\"num\">{}</div><div class=\"lbl\">{}</div></div>",
-        esc(num),
-        esc(lbl)
+        "<div class=\"metric\"><div class=\"v\">{}</div><div class=\"k\">{}</div></div>",
+        esc(v),
+        esc(k)
     )
 }
 
-fn hbar(label: &str, value: &str, frac: f64, color: &str) -> String {
+fn eyebrow(title: &str) -> String {
+    format!(
+        "<div class=\"eyebrow\"><h2>{}</h2><div class=\"ln\"></div></div>",
+        esc(title)
+    )
+}
+
+fn bar(label: &str, value: &str, frac: f64, color: &str) -> String {
     let w = (frac.clamp(0.0, 1.0) * 100.0).max(0.0);
     format!(
-        "<div class=\"bar-row\"><div class=\"bar-label\">{}</div>\
-         <div class=\"bar-track\"><div class=\"bar-fill\" style=\"width:{w:.2}%;background:{color}\"></div></div>\
-         <div class=\"bar-val\">{}</div></div>",
+        "<div class=\"bar\"><div class=\"lbl\">{}</div>\
+         <div class=\"track\"><div class=\"fill\" style=\"width:{w:.2}%;background:{color}\"></div></div>\
+         <div class=\"val\">{}</div></div>",
         esc(label),
         esc(value)
     )
@@ -121,10 +176,15 @@ fn page(title: &str, body: &str) -> String {
     format!(
         "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\
          \n<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\
-         \n<title>{}</title>\n<style>{CSS}</style>\n</head>\n<body>\n<div class=\"wrap\">\n{body}\n\
-         <div class=\"foot\">Generated by <span class=\"mono\">cyto summary</span> v{}</div>\n\
-         </div>\n</body>\n</html>\n",
+         \n<title>{}</title>\n<style>{CSS}</style>\n</head>\n<body>\n<div class=\"page\">\n{body}\n</div>\n</body>\n</html>\n",
         esc(title),
+    )
+}
+
+fn footer(left: &str) -> String {
+    format!(
+        "<div class=\"foot\"><span>{}</span><span class=\"mono\">cyto summary v{}</span></div>",
+        esc(left),
         env!("CARGO_PKG_VERSION"),
     )
 }
@@ -154,8 +214,8 @@ fn knee_svg(probes: &[ProbeSummary]) -> String {
         .unwrap_or(1)
         .max(1);
 
-    let (w, h) = (780.0_f64, 340.0_f64);
-    let (pl, pr, pt, pb) = (56.0_f64, 16.0_f64, 14.0_f64, 40.0_f64);
+    let (w, h) = (720.0_f64, 300.0_f64);
+    let (pl, pr, pt, pb) = (54.0_f64, 14.0_f64, 12.0_f64, 38.0_f64);
     let iw = w - pl - pr;
     let ih = h - pt - pb;
     let lx = (max_rank as f64).log10().max(1e-9);
@@ -166,20 +226,7 @@ fn knee_svg(probes: &[ProbeSummary]) -> String {
     let mut s = String::new();
     let _ = write!(
         s,
-        "<svg class=\"plot\" viewBox=\"0 0 {w} {h}\" preserveAspectRatio=\"xMidYMid meet\" role=\"img\">"
-    );
-    // axes
-    let _ = write!(
-        s,
-        "<line x1=\"{pl}\" y1=\"{pt}\" x2=\"{pl}\" y2=\"{}\" stroke=\"var(--line)\"/>",
-        pt + ih
-    );
-    let _ = write!(
-        s,
-        "<line x1=\"{pl}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" stroke=\"var(--line)\"/>",
-        pt + ih,
-        pl + iw,
-        pt + ih
+        "<svg class=\"plot\" viewBox=\"0 0 {w} {h}\" preserveAspectRatio=\"xMidYMid meet\" role=\"img\" aria-label=\"Barcode rank plot\">"
     );
     // x gridlines (powers of 10)
     let mut e = 0u32;
@@ -187,12 +234,12 @@ fn knee_svg(probes: &[ProbeSummary]) -> String {
         let x = px(10u64.pow(e));
         let _ = write!(
             s,
-            "<line x1=\"{x:.1}\" y1=\"{pt}\" x2=\"{x:.1}\" y2=\"{:.1}\" stroke=\"var(--line)\" stroke-dasharray=\"2 3\" opacity=\"0.6\"/>",
+            "<line x1=\"{x:.1}\" y1=\"{pt}\" x2=\"{x:.1}\" y2=\"{:.1}\" stroke=\"var(--rule)\"/>",
             pt + ih
         );
         let _ = write!(
             s,
-            "<text x=\"{x:.1}\" y=\"{:.1}\" fill=\"var(--muted)\" font-size=\"11\" text-anchor=\"middle\">{}</text>",
+            "<text x=\"{x:.1}\" y=\"{:.1}\" fill=\"var(--faint)\" font-size=\"10.5\" font-family=\"ui-monospace,Menlo,monospace\" text-anchor=\"middle\">{}</text>",
             pt + ih + 16.0,
             compact(10u64.pow(e))
         );
@@ -204,28 +251,41 @@ fn knee_svg(probes: &[ProbeSummary]) -> String {
         let y = py(10u64.pow(e));
         let _ = write!(
             s,
-            "<line x1=\"{pl}\" y1=\"{y:.1}\" x2=\"{:.1}\" y2=\"{y:.1}\" stroke=\"var(--line)\" stroke-dasharray=\"2 3\" opacity=\"0.6\"/>",
+            "<line x1=\"{pl}\" y1=\"{y:.1}\" x2=\"{:.1}\" y2=\"{y:.1}\" stroke=\"var(--rule)\"/>",
             pl + iw
         );
         let _ = write!(
             s,
-            "<text x=\"{:.1}\" y=\"{:.1}\" fill=\"var(--muted)\" font-size=\"11\" text-anchor=\"end\">{}</text>",
-            pl - 6.0,
+            "<text x=\"{:.1}\" y=\"{:.1}\" fill=\"var(--faint)\" font-size=\"10.5\" font-family=\"ui-monospace,Menlo,monospace\" text-anchor=\"end\">{}</text>",
+            pl - 7.0,
             y + 3.5,
             compact(10u64.pow(e))
         );
         e += 1;
     }
-    // axis titles
+    // axes (drawn over gridlines)
     let _ = write!(
         s,
-        "<text x=\"{:.1}\" y=\"{:.1}\" fill=\"var(--muted)\" font-size=\"11\" text-anchor=\"middle\">Barcode rank</text>",
-        pl + iw / 2.0,
-        h - 4.0
+        "<line x1=\"{pl}\" y1=\"{pt}\" x2=\"{pl}\" y2=\"{:.1}\" stroke=\"var(--rule-strong)\"/>",
+        pt + ih
     );
     let _ = write!(
         s,
-        "<text transform=\"rotate(-90 12 {:.1})\" x=\"12\" y=\"{:.1}\" fill=\"var(--muted)\" font-size=\"11\" text-anchor=\"middle\">UMIs per barcode</text>",
+        "<line x1=\"{pl}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" stroke=\"var(--rule-strong)\"/>",
+        pt + ih,
+        pl + iw,
+        pt + ih
+    );
+    // axis titles
+    let _ = write!(
+        s,
+        "<text x=\"{:.1}\" y=\"{:.1}\" fill=\"var(--muted)\" font-size=\"11\" text-anchor=\"middle\">barcode rank</text>",
+        pl + iw / 2.0,
+        h - 3.0
+    );
+    let _ = write!(
+        s,
+        "<text transform=\"rotate(-90 11 {:.1})\" x=\"11\" y=\"{:.1}\" fill=\"var(--muted)\" font-size=\"11\" text-anchor=\"middle\">UMIs per barcode</text>",
         pt + ih / 2.0,
         pt + ih / 2.0
     );
@@ -241,23 +301,25 @@ fn knee_svg(probes: &[ProbeSummary]) -> String {
             .join(" ");
         let _ = write!(
             s,
-            "<polyline points=\"{pts}\" fill=\"none\" stroke=\"{color}\" stroke-width=\"1.8\"/>"
+            "<polyline points=\"{pts}\" fill=\"none\" stroke=\"{color}\" stroke-width=\"1.6\" stroke-linejoin=\"round\"/>"
         );
     }
-    // legend
-    let mut ly0 = pt + 6.0;
+    // legend (top-right, over the empty high-rank corner)
+    let mut ly0 = pt + 10.0;
     for (i, p) in with_data.iter().enumerate() {
         let color = PALETTE[i % PALETTE.len()];
-        let x = pl + iw - 96.0;
+        let x = pl + iw - 90.0;
         let _ = write!(
             s,
-            "<rect x=\"{x:.1}\" y=\"{:.1}\" width=\"10\" height=\"10\" fill=\"{color}\" rx=\"2\"/>",
-            ly0 - 8.0
+            "<line x1=\"{x:.1}\" y1=\"{:.1}\" x2=\"{:.1}\" y2=\"{:.1}\" stroke=\"{color}\" stroke-width=\"2\"/>",
+            ly0 - 3.5,
+            x + 16.0,
+            ly0 - 3.5
         );
         let _ = write!(
             s,
-            "<text x=\"{:.1}\" y=\"{ly0:.1}\" fill=\"var(--ink)\" font-size=\"11\">{}</text>",
-            x + 15.0,
+            "<text x=\"{:.1}\" y=\"{ly0:.1}\" fill=\"var(--ink)\" font-size=\"11\" font-family=\"ui-monospace,Menlo,monospace\">{}</text>",
+            x + 22.0,
             esc(&p.name)
         );
         ly0 += 15.0;
@@ -267,21 +329,92 @@ fn knee_svg(probes: &[ProbeSummary]) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// per-sample report
+// per-sample sections
 // ---------------------------------------------------------------------------
 
-fn mapping_card(r: &SampleReport) -> String {
+fn sample_metrics(r: &SampleReport) -> String {
+    let mut m = String::new();
+    let total_reads = r.mapping.as_ref().map_or(r.total_reads, |x| x.total_reads);
+    m.push_str(&metric(&compact(total_reads), "Reads"));
+    if let Some(mp) = &r.mapping {
+        m.push_str(&metric(&pct(mp.mapped_reads_frac), "Mapped"));
+    }
+    if let Some(s) = r.overall_saturation {
+        m.push_str(&metric(&pct(s), "Saturation"));
+    }
+    m.push_str(&metric(&compact(r.total_umis), "UMIs"));
+    let barcodes: u64 = r.probes.iter().map(|p| p.n_barcodes).sum();
+    m.push_str(&metric(&compact(barcodes), "Barcodes"));
+    if r.kind == SampleKind::Crispr {
+        let assigned: u64 = r
+            .probes
+            .iter()
+            .filter_map(|p| p.assignment.as_ref().map(|a| a.n_assigned))
+            .sum();
+        if assigned > 0 {
+            m.push_str(&metric(&compact(assigned), "Cells assigned"));
+        }
+    }
+    format!("<div class=\"metrics\">{m}</div>")
+}
+
+/// The Cell-Ranger-familiar block: library metrics on the left, barcode-rank on the right.
+fn cells_section(r: &SampleReport) -> String {
+    let svg = knee_svg(&r.probes);
+    if svg.is_empty() {
+        return String::new();
+    }
+    let barcodes: u64 = r.probes.iter().map(|p| p.n_barcodes).sum();
+    let mut keys = String::new();
+    let _ = write!(
+        keys,
+        "<tr><td>Barcodes observed</td><td>{}</td></tr>",
+        int(barcodes)
+    );
+    let _ = write!(
+        keys,
+        "<tr><td>Total UMIs</td><td>{}</td></tr>",
+        int(r.total_umis)
+    );
+    if let Some(s) = r.overall_saturation {
+        let _ = write!(
+            keys,
+            "<tr><td>Sequencing saturation</td><td>{}</td></tr>",
+            pct(s)
+        );
+    }
+    if let Some(mp) = &r.mapping {
+        let _ = write!(
+            keys,
+            "<tr><td>Reads in library</td><td>{}</td></tr>",
+            int(mp.total_reads)
+        );
+        let _ = write!(
+            keys,
+            "<tr><td>Reads mapped</td><td>{}</td></tr>",
+            pct(mp.mapped_reads_frac)
+        );
+    }
+    let _ = write!(keys, "<tr><td>Probes</td><td>{}</td></tr>", r.probes.len());
+
+    format!(
+        "<section class=\"section\">{}\
+         <div class=\"split\"><table class=\"keys\"><tbody>{keys}</tbody></table>\
+         <figure>{svg}<figcaption>UMIs per barcode vs. rank (log&ndash;log), one line per probe. The knee separates cell-associated barcodes from background.</figcaption></figure></div></section>",
+        eyebrow("Cells & barcodes"),
+    )
+}
+
+fn mapping_section(r: &SampleReport) -> String {
     let Some(m) = &r.mapping else {
         return String::new();
     };
-    let mut bars = String::new();
-    bars.push_str(&hbar(
+    let mut bars = bar(
         "Mapped",
-        &format!("{} ({})", int(m.mapped_reads), pct(m.mapped_reads_frac)),
+        &format!("{} · {}", int(m.mapped_reads), pct(m.mapped_reads_frac)),
         m.mapped_reads_frac,
-        "var(--good)",
-    ));
-    // unmapped breakdown (fractions are of total unmapped reads)
+        "var(--accent)",
+    );
     let u = &m.unmapped;
     let breakdown = [
         ("Missing feature", u.missing_feature, u.missing_feature_frac),
@@ -298,29 +431,36 @@ fn mapping_card(r: &SampleReport) -> String {
         ("Missing probe", u.missing_probe, u.missing_probe_frac),
         ("UMI truncated", u.umi_truncated, u.umi_truncated_frac),
     ];
-    let mut rows = String::new();
+    let mut reasons = String::new();
     for (label, count, frac) in breakdown {
         if count == 0 {
             continue;
         }
-        rows.push_str(&hbar(
+        reasons.push_str(&bar(
             label,
-            &format!("{} ({} of unmapped)", int(count), pct(frac)),
+            &format!("{} · {} of unmapped", int(count), pct(frac)),
             frac,
-            "var(--bad)",
+            "var(--faint)",
         ));
     }
+    if !reasons.is_empty() {
+        let _ = write!(
+            bars,
+            "<div class=\"subhead\">Unmapped reads by reason</div>{reasons}"
+        );
+    }
     format!(
-        "<div class=\"card\"><h2>Read mapping</h2>\
-         <div class=\"hint\">{} total reads &middot; {} mapped &middot; {} unmapped</div>{bars}\
-         <div style=\"height:6px\"></div><div class=\"muted\" style=\"font-size:12px;margin-bottom:6px\">Unmapped reads by reason (share of unmapped):</div>{rows}</div>",
+        "<section class=\"section\">{}\
+         <div class=\"hint\">{} reads total &middot; {} mapped &middot; {} unmapped. Reason shares are of unmapped reads and can overlap.</div>\
+         <div class=\"bars\">{bars}</div></section>",
+        eyebrow("Read mapping"),
         int(m.total_reads),
         int(m.mapped_reads),
         int(m.unmapped_reads),
     )
 }
 
-fn probe_table(r: &SampleReport) -> String {
+fn probe_section(r: &SampleReport) -> String {
     if r.probes.is_empty() {
         return String::new();
     }
@@ -330,7 +470,7 @@ fn probe_table(r: &SampleReport) -> String {
          <th>Median reads/bc</th><th>Median UMIs/bc</th><th>UMI corr.</th>",
     );
     if is_crispr {
-        head.push_str("<th>Cells assigned</th><th>Dominant MOI</th>");
+        head.push_str("<th>Cells assigned</th><th>Dom. MOI</th>");
     }
     head.push_str("</tr>");
 
@@ -355,7 +495,7 @@ fn probe_table(r: &SampleReport) -> String {
             if let Some(a) = &p.assignment {
                 let _ = write!(
                     body,
-                    "<td>{} ({})</td><td>{}</td>",
+                    "<td>{} · {}</td><td>{}</td>",
                     int(a.n_assigned),
                     pct(a.assigned_frac),
                     a.dominant_moi,
@@ -367,28 +507,17 @@ fn probe_table(r: &SampleReport) -> String {
         body.push_str("</tr>");
     }
     format!(
-        "<div class=\"card\"><h2>Per-probe metrics</h2>\
+        "<section class=\"section\">{}\
          <div class=\"hint\">Saturation = 1 &minus; UMIs / reads (endpoint). Medians are per observed barcode.</div>\
-         <div class=\"overflow\"><table><thead>{head}</thead><tbody>{body}</tbody></table></div></div>"
+         <div class=\"overflow\"><table class=\"data\"><thead>{head}</thead><tbody>{body}</tbody></table></div></section>",
+        eyebrow("Per-probe metrics"),
     )
 }
 
-fn knee_card(r: &SampleReport) -> String {
-    let svg = knee_svg(&r.probes);
-    if svg.is_empty() {
-        return String::new();
-    }
-    format!(
-        "<div class=\"card\"><h2>Barcode-rank plot</h2>\
-         <div class=\"hint\">UMIs per barcode vs. rank (log&ndash;log). The knee separates cell-associated barcodes from background.</div>{svg}</div>"
-    )
-}
-
-fn moi_card(r: &SampleReport) -> String {
+fn moi_section(r: &SampleReport) -> String {
     if r.kind != SampleKind::Crispr {
         return String::new();
     }
-    // Aggregate MOI distribution across probes.
     let mut agg: std::collections::BTreeMap<i64, u64> = std::collections::BTreeMap::new();
     for p in &r.probes {
         if let Some(a) = &p.assignment {
@@ -405,21 +534,33 @@ fn moi_card(r: &SampleReport) -> String {
     let mut rows = String::new();
     for (moi, count) in agg.iter().take(15) {
         let frac_total = *count as f64 / total as f64;
-        rows.push_str(&hbar(
-            &format!("MOI = {moi}"),
-            &format!("{} ({})", int(*count), pct(frac_total)),
+        rows.push_str(&bar(
+            &format!("{moi} guide(s)"),
+            &format!("{} · {}", int(*count), pct(frac_total)),
             *count as f64 / max,
             "var(--accent)",
         ));
     }
     format!(
-        "<div class=\"card\"><h2>Guide multiplicity (MOI)</h2>\
-         <div class=\"hint\">Number of assigned cells by guides-per-cell, across all probes ({} cells).</div>{rows}</div>",
-        int(total)
+        "<section class=\"section\">{}\
+         <div class=\"hint\">Assigned cells by guides-per-cell, across all probes ({} cells).</div>\
+         <div class=\"bars\">{rows}</div></section>",
+        eyebrow("Guide multiplicity"),
+        int(total),
     )
 }
 
-fn timings_card(r: &SampleReport) -> String {
+fn fmt_dur(sec: f64) -> String {
+    if sec >= 3600.0 {
+        format!("{:.1} h", sec / 3600.0)
+    } else if sec >= 60.0 {
+        format!("{:.1} min", sec / 60.0)
+    } else {
+        format!("{sec:.1} s")
+    }
+}
+
+fn timing_section(r: &SampleReport) -> String {
     if r.timings.is_empty() {
         return String::new();
     }
@@ -428,7 +569,6 @@ fn timings_card(r: &SampleReport) -> String {
         *agg.entry(t.module.clone()).or_insert(0.0) += t.elapsed;
     }
     let max = agg.values().copied().fold(0.0_f64, f64::max).max(1e-9);
-    // Present in a stable, pipeline-ish order then any extras.
     let order = [
         "Mapping",
         "InitialSort",
@@ -443,32 +583,24 @@ fn timings_card(r: &SampleReport) -> String {
     let mut seen: Vec<String> = Vec::new();
     for name in order {
         if let Some(sec) = agg.get(name) {
-            rows.push_str(&hbar(name, &fmt_dur(*sec), *sec / max, "var(--accent)"));
+            rows.push_str(&bar(name, &fmt_dur(*sec), *sec / max, "var(--faint)"));
             seen.push(name.to_string());
         }
     }
     for (name, sec) in &agg {
         if !seen.contains(name) {
-            rows.push_str(&hbar(name, &fmt_dur(*sec), *sec / max, "var(--accent)"));
+            rows.push_str(&bar(name, &fmt_dur(*sec), *sec / max, "var(--faint)"));
         }
     }
     format!(
-        "<div class=\"card\"><h2>Pipeline timing</h2>\
-         <div class=\"hint\">Wall-clock summed per module (post-mapping steps run in parallel across probes).</div>{rows}</div>"
+        "<section class=\"section\">{}\
+         <div class=\"hint\">Wall-clock summed per module; post-mapping steps run in parallel across probes.</div>\
+         <div class=\"bars\">{rows}</div></section>",
+        eyebrow("Pipeline timing"),
     )
 }
 
-fn fmt_dur(sec: f64) -> String {
-    if sec >= 3600.0 {
-        format!("{:.1} h", sec / 3600.0)
-    } else if sec >= 60.0 {
-        format!("{:.1} min", sec / 60.0)
-    } else {
-        format!("{sec:.1} s")
-    }
-}
-
-fn libraries_card(r: &SampleReport) -> String {
+fn library_section(r: &SampleReport) -> String {
     if r.libraries.is_empty() {
         return String::new();
     }
@@ -486,79 +618,56 @@ fn libraries_card(r: &SampleReport) -> String {
         );
     }
     format!(
-        "<div class=\"card\"><h2>Reference libraries</h2>\
-         <div class=\"overflow\"><table><thead><tr><th>Library</th><th>Elements</th><th>Aggregated</th><th>Mate</th><th>Window</th><th>Match</th></tr></thead><tbody>{body}</tbody></table></div></div>"
+        "<section class=\"section\">{}\
+         <div class=\"overflow\"><table class=\"data\"><thead><tr><th>Library</th><th>Elements</th><th>Aggregated</th><th>Mate</th><th>Window</th><th>Match</th></tr></thead><tbody>{body}</tbody></table></div></section>",
+        eyebrow("Reference libraries"),
     )
 }
 
-fn notes_card(r: &SampleReport) -> String {
+fn alerts(r: &SampleReport) -> String {
     if r.notes.is_empty() {
         return String::new();
     }
     let mut items = String::new();
     for n in &r.notes {
-        let _ = write!(items, "<div class=\"note\">&#9888; {}</div>", esc(n));
+        let _ = write!(
+            items,
+            "<div class=\"alert\"><b>Note</b> &nbsp;{}</div>",
+            esc(n)
+        );
     }
-    format!("<div class=\"card\"><h2>Notes</h2>{items}</div>")
-}
-
-fn sample_kpis(r: &SampleReport) -> String {
-    let mut tiles = String::new();
-    let total_reads = r.mapping.as_ref().map_or(r.total_reads, |m| m.total_reads);
-    tiles.push_str(&kpi(&compact(total_reads), "Total reads"));
-    if let Some(m) = &r.mapping {
-        tiles.push_str(&kpi(&pct(m.mapped_reads_frac), "Reads mapped"));
-    }
-    if let Some(s) = r.overall_saturation {
-        tiles.push_str(&kpi(&pct(s), "Sequencing saturation"));
-    }
-    tiles.push_str(&kpi(&r.probes.len().to_string(), "Probes"));
-    tiles.push_str(&kpi(&compact(r.total_umis), "Total UMIs"));
-    let barcodes: u64 = r.probes.iter().map(|p| p.n_barcodes).sum();
-    tiles.push_str(&kpi(&compact(barcodes), "Barcodes observed"));
-    if r.kind == SampleKind::Crispr {
-        let assigned: u64 = r
-            .probes
-            .iter()
-            .filter_map(|p| p.assignment.as_ref().map(|a| a.n_assigned))
-            .sum();
-        if assigned > 0 {
-            tiles.push_str(&kpi(&compact(assigned), "Cells assigned"));
-        }
-    }
-    format!("<div class=\"kpis\">{tiles}</div>")
+    items
 }
 
 /// Render a full per-sample HTML report.
 pub fn render_sample(r: &SampleReport) -> String {
-    let kind_class = match r.kind {
-        SampleKind::Gex => "gex",
-        SampleKind::Crispr => "crispr",
-        SampleKind::Unknown => "unknown",
+    let meta = {
+        let mut m = esc(&r.path);
+        if let Some(s) = r.runtime_sec {
+            let _ = write!(m, "  ·  mapping {}", fmt_dur(s));
+        }
+        m
     };
-    let runtime = r
-        .runtime_sec
-        .map(|s| format!(" &middot; mapping {}", fmt_dur(s)))
-        .unwrap_or_default();
     let header = format!(
-        "<div class=\"top\"><h1>{}</h1><span class=\"badge {kind_class}\">{}</span></div>\
-         <div class=\"muted mono\" style=\"margin-top:-14px;margin-bottom:18px\">{}{runtime}</div>",
+        "<div class=\"masthead\"><div><h1 class=\"title\">{}<span class=\"kind\">{}</span></h1>\
+         <div class=\"sub\">{meta}</div></div>\
+         <div class=\"brand\"><b>cyto</b>QC report</div></div>",
         esc(&r.sample),
         esc(r.kind.label()),
-        esc(&r.path),
     );
     let body = format!(
-        "{header}{}{}{}{}{}{}{}{}",
-        sample_kpis(r),
-        mapping_card(r),
-        probe_table(r),
-        knee_card(r),
-        moi_card(r),
-        timings_card(r),
-        libraries_card(r),
-        notes_card(r),
+        "{header}{}{}{}{}{}{}{}{}{}",
+        alerts(r),
+        sample_metrics(r),
+        cells_section(r),
+        mapping_section(r),
+        probe_section(r),
+        moi_section(r),
+        timing_section(r),
+        library_section(r),
+        footer(&r.path),
     );
-    page(&format!("{} — cyto report", r.sample), &body)
+    page(&format!("{} — cyto QC report", r.sample), &body)
 }
 
 // ---------------------------------------------------------------------------
@@ -574,11 +683,11 @@ pub fn render_master(run_name: &str, reports: &[(&SampleReport, String)]) -> Str
         .sum();
     let total_umis: u64 = reports.iter().map(|(r, _)| r.total_umis).sum();
 
-    let mut tiles = String::new();
-    tiles.push_str(&kpi(&n.to_string(), "Samples"));
-    tiles.push_str(&kpi(&compact(total_reads), "Total reads"));
-    tiles.push_str(&kpi(&compact(total_umis), "Total UMIs"));
-    let kpis = format!("<div class=\"kpis\">{tiles}</div>");
+    let mut m = String::new();
+    m.push_str(&metric(&n.to_string(), "Samples"));
+    m.push_str(&metric(&compact(total_reads), "Reads"));
+    m.push_str(&metric(&compact(total_umis), "UMIs"));
+    let metrics = format!("<div class=\"metrics\">{m}</div>");
 
     let mut body_rows = String::new();
     for (r, href) in reports {
@@ -615,19 +724,21 @@ pub fn render_master(run_name: &str, reports: &[(&SampleReport, String)]) -> Str
         );
     }
     let table = format!(
-        "<div class=\"card\"><h2>Samples</h2><div class=\"overflow\"><table><thead>\
+        "<section class=\"section\">{}<div class=\"overflow\"><table class=\"data\"><thead>\
          <tr><th>Sample</th><th>Type</th><th>Reads</th><th>Mapped</th><th>Probes</th><th>UMIs</th><th>Saturation</th><th>Cells assigned</th></tr>\
-         </thead><tbody>{body_rows}</tbody></table></div></div>"
+         </thead><tbody>{body_rows}</tbody></table></div></section>",
+        eyebrow("Samples"),
     );
 
     let header = format!(
-        "<div class=\"top\"><h1>{}</h1><span class=\"badge\">run</span></div>\
-         <div class=\"muted\" style=\"margin-top:-14px;margin-bottom:18px\">{n} sample report{}</div>",
+        "<div class=\"masthead\"><div><h1 class=\"title\">{}<span class=\"kind\">run</span></h1>\
+         <div class=\"sub\">{n} sample{} · click a sample for its full report</div></div>\
+         <div class=\"brand\"><b>cyto</b>QC report</div></div>",
         esc(run_name),
         if n == 1 { "" } else { "s" },
     );
     page(
         &format!("{run_name} — cyto run report"),
-        &format!("{header}{kpis}{table}"),
+        &format!("{header}{metrics}{table}{}", footer(run_name)),
     )
 }

--- a/crates/cyto-summary/src/render.rs
+++ b/crates/cyto-summary/src/render.rs
@@ -1,0 +1,633 @@
+//! Render `SampleReport`s into self-contained HTML.
+//!
+//! No external assets: all CSS is inlined and plots are hand-built SVG, so a
+//! report is a single portable file. Two entry points: [`render_sample`] for a
+//! per-sample report and [`render_master`] for the cross-sample index.
+
+use std::fmt::Write as _;
+
+use crate::model::{ProbeSummary, SampleKind, SampleReport};
+
+const PALETTE: [&str; 10] = [
+    "#2563eb", "#dc2626", "#059669", "#d97706", "#7c3aed", "#0891b2", "#db2777", "#65a30d",
+    "#9333ea", "#0d9488",
+];
+
+const CSS: &str = r#"
+:root{--bg:#f6f7f9;--card:#fff;--ink:#1a1d21;--muted:#6b7280;--line:#e5e7eb;--accent:#2563eb;--good:#059669;--warn:#d97706;--bad:#dc2626;--track:#eef0f3}
+@media (prefers-color-scheme:dark){:root{--bg:#0f1216;--card:#171b21;--ink:#e6e9ee;--muted:#9aa4b2;--line:#262c35;--accent:#60a5fa;--track:#20262e}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+.wrap{max-width:960px;margin:0 auto;padding:28px 20px 64px}
+h1{font-size:22px;margin:0 0 2px}
+h2{font-size:15px;margin:0 0 14px;font-weight:600}
+a{color:var(--accent);text-decoration:none}
+a:hover{text-decoration:underline}
+.muted{color:var(--muted)}
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px}
+.top{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin-bottom:20px}
+.badge{display:inline-block;padding:2px 9px;border-radius:999px;font-size:12px;font-weight:600;background:var(--accent);color:#fff}
+.badge.gex{background:#2563eb}.badge.crispr{background:#7c3aed}.badge.unknown{background:#6b7280}
+.card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin-bottom:16px}
+.kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-bottom:16px}
+.kpi{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+.kpi .num{font-size:22px;font-weight:700;letter-spacing:-.02em}
+.kpi .lbl{font-size:12px;color:var(--muted);margin-top:2px}
+table{width:100%;border-collapse:collapse;font-variant-numeric:tabular-nums}
+th,td{text-align:right;padding:7px 10px;border-bottom:1px solid var(--line);white-space:nowrap}
+th:first-child,td:first-child{text-align:left}
+th{font-size:12px;color:var(--muted);font-weight:600}
+tbody tr:last-child td{border-bottom:none}
+.overflow{overflow-x:auto}
+.bar-row{display:flex;align-items:center;gap:10px;margin:6px 0}
+.bar-label{width:170px;flex:none;font-size:13px}
+.bar-track{flex:1;height:14px;background:var(--track);border-radius:7px;overflow:hidden}
+.bar-fill{height:100%;border-radius:7px}
+.bar-val{width:150px;flex:none;text-align:right;font-size:12px;font-variant-numeric:tabular-nums;color:var(--muted)}
+.plot{width:100%;height:auto;overflow:visible}
+.note{color:var(--warn);font-size:13px;margin:3px 0}
+.foot{color:var(--muted);font-size:12px;margin-top:8px;text-align:center}
+.hint{font-size:12px;color:var(--muted);margin:-6px 0 12px}
+"#;
+
+// ---------------------------------------------------------------------------
+// formatting helpers
+// ---------------------------------------------------------------------------
+
+fn esc(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Group digits with thousands separators.
+fn int(n: u64) -> String {
+    let s = n.to_string();
+    let b = s.as_bytes();
+    let len = b.len();
+    let mut out = String::with_capacity(len + len / 3);
+    for (i, c) in b.iter().enumerate() {
+        if i > 0 && (len - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(*c as char);
+    }
+    out
+}
+
+/// Compact magnitude (e.g. `10.72B`) for headline tiles.
+fn compact(n: u64) -> String {
+    let f = n as f64;
+    if f >= 1e9 {
+        format!("{:.2}B", f / 1e9)
+    } else if f >= 1e6 {
+        format!("{:.2}M", f / 1e6)
+    } else if f >= 1e3 {
+        format!("{:.1}K", f / 1e3)
+    } else {
+        n.to_string()
+    }
+}
+
+fn pct(frac: f64) -> String {
+    format!("{:.1}%", frac * 100.0)
+}
+
+fn f1(x: f64) -> String {
+    format!("{x:.1}")
+}
+
+fn kpi(num: &str, lbl: &str) -> String {
+    format!(
+        "<div class=\"kpi\"><div class=\"num\">{}</div><div class=\"lbl\">{}</div></div>",
+        esc(num),
+        esc(lbl)
+    )
+}
+
+fn hbar(label: &str, value: &str, frac: f64, color: &str) -> String {
+    let w = (frac.clamp(0.0, 1.0) * 100.0).max(0.0);
+    format!(
+        "<div class=\"bar-row\"><div class=\"bar-label\">{}</div>\
+         <div class=\"bar-track\"><div class=\"bar-fill\" style=\"width:{w:.2}%;background:{color}\"></div></div>\
+         <div class=\"bar-val\">{}</div></div>",
+        esc(label),
+        esc(value)
+    )
+}
+
+fn page(title: &str, body: &str) -> String {
+    format!(
+        "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\
+         \n<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\
+         \n<title>{}</title>\n<style>{CSS}</style>\n</head>\n<body>\n<div class=\"wrap\">\n{body}\n\
+         <div class=\"foot\">Generated by <span class=\"mono\">cyto summary</span> v{}</div>\n\
+         </div>\n</body>\n</html>\n",
+        esc(title),
+        env!("CARGO_PKG_VERSION"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// SVG barcode-rank knee plot
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::many_single_char_names, clippy::too_many_lines)]
+fn knee_svg(probes: &[ProbeSummary]) -> String {
+    let with_data: Vec<&ProbeSummary> = probes.iter().filter(|p| !p.knee.is_empty()).collect();
+    if with_data.is_empty() {
+        return String::new();
+    }
+    let max_rank = with_data
+        .iter()
+        .flat_map(|p| p.knee.iter())
+        .map(|k| k.rank)
+        .max()
+        .unwrap_or(1)
+        .max(1);
+    let max_umis = with_data
+        .iter()
+        .flat_map(|p| p.knee.iter())
+        .map(|k| k.umis)
+        .max()
+        .unwrap_or(1)
+        .max(1);
+
+    let (w, h) = (780.0_f64, 340.0_f64);
+    let (pl, pr, pt, pb) = (56.0_f64, 16.0_f64, 14.0_f64, 40.0_f64);
+    let iw = w - pl - pr;
+    let ih = h - pt - pb;
+    let lx = (max_rank as f64).log10().max(1e-9);
+    let ly = ((max_umis + 1) as f64).log10().max(1e-9);
+    let px = |rank: u64| pl + (rank as f64).log10().clamp(0.0, lx) / lx * iw;
+    let py = |umis: u64| pt + (1.0 - ((umis + 1) as f64).log10().clamp(0.0, ly) / ly) * ih;
+
+    let mut s = String::new();
+    let _ = write!(
+        s,
+        "<svg class=\"plot\" viewBox=\"0 0 {w} {h}\" preserveAspectRatio=\"xMidYMid meet\" role=\"img\">"
+    );
+    // axes
+    let _ = write!(
+        s,
+        "<line x1=\"{pl}\" y1=\"{pt}\" x2=\"{pl}\" y2=\"{}\" stroke=\"var(--line)\"/>",
+        pt + ih
+    );
+    let _ = write!(
+        s,
+        "<line x1=\"{pl}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" stroke=\"var(--line)\"/>",
+        pt + ih,
+        pl + iw,
+        pt + ih
+    );
+    // x gridlines (powers of 10)
+    let mut e = 0u32;
+    while 10u64.pow(e) <= max_rank {
+        let x = px(10u64.pow(e));
+        let _ = write!(
+            s,
+            "<line x1=\"{x:.1}\" y1=\"{pt}\" x2=\"{x:.1}\" y2=\"{:.1}\" stroke=\"var(--line)\" stroke-dasharray=\"2 3\" opacity=\"0.6\"/>",
+            pt + ih
+        );
+        let _ = write!(
+            s,
+            "<text x=\"{x:.1}\" y=\"{:.1}\" fill=\"var(--muted)\" font-size=\"11\" text-anchor=\"middle\">{}</text>",
+            pt + ih + 16.0,
+            compact(10u64.pow(e))
+        );
+        e += 1;
+    }
+    // y gridlines (powers of 10)
+    let mut e = 0u32;
+    while 10u64.pow(e) <= max_umis {
+        let y = py(10u64.pow(e));
+        let _ = write!(
+            s,
+            "<line x1=\"{pl}\" y1=\"{y:.1}\" x2=\"{:.1}\" y2=\"{y:.1}\" stroke=\"var(--line)\" stroke-dasharray=\"2 3\" opacity=\"0.6\"/>",
+            pl + iw
+        );
+        let _ = write!(
+            s,
+            "<text x=\"{:.1}\" y=\"{:.1}\" fill=\"var(--muted)\" font-size=\"11\" text-anchor=\"end\">{}</text>",
+            pl - 6.0,
+            y + 3.5,
+            compact(10u64.pow(e))
+        );
+        e += 1;
+    }
+    // axis titles
+    let _ = write!(
+        s,
+        "<text x=\"{:.1}\" y=\"{:.1}\" fill=\"var(--muted)\" font-size=\"11\" text-anchor=\"middle\">Barcode rank</text>",
+        pl + iw / 2.0,
+        h - 4.0
+    );
+    let _ = write!(
+        s,
+        "<text transform=\"rotate(-90 12 {:.1})\" x=\"12\" y=\"{:.1}\" fill=\"var(--muted)\" font-size=\"11\" text-anchor=\"middle\">UMIs per barcode</text>",
+        pt + ih / 2.0,
+        pt + ih / 2.0
+    );
+
+    // polylines
+    for (i, p) in with_data.iter().enumerate() {
+        let color = PALETTE[i % PALETTE.len()];
+        let pts: String = p
+            .knee
+            .iter()
+            .map(|k| format!("{:.1},{:.1}", px(k.rank), py(k.umis)))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let _ = write!(
+            s,
+            "<polyline points=\"{pts}\" fill=\"none\" stroke=\"{color}\" stroke-width=\"1.8\"/>"
+        );
+    }
+    // legend
+    let mut ly0 = pt + 6.0;
+    for (i, p) in with_data.iter().enumerate() {
+        let color = PALETTE[i % PALETTE.len()];
+        let x = pl + iw - 96.0;
+        let _ = write!(
+            s,
+            "<rect x=\"{x:.1}\" y=\"{:.1}\" width=\"10\" height=\"10\" fill=\"{color}\" rx=\"2\"/>",
+            ly0 - 8.0
+        );
+        let _ = write!(
+            s,
+            "<text x=\"{:.1}\" y=\"{ly0:.1}\" fill=\"var(--ink)\" font-size=\"11\">{}</text>",
+            x + 15.0,
+            esc(&p.name)
+        );
+        ly0 += 15.0;
+    }
+    s.push_str("</svg>");
+    s
+}
+
+// ---------------------------------------------------------------------------
+// per-sample report
+// ---------------------------------------------------------------------------
+
+fn mapping_card(r: &SampleReport) -> String {
+    let Some(m) = &r.mapping else {
+        return String::new();
+    };
+    let mut bars = String::new();
+    bars.push_str(&hbar(
+        "Mapped",
+        &format!("{} ({})", int(m.mapped_reads), pct(m.mapped_reads_frac)),
+        m.mapped_reads_frac,
+        "var(--good)",
+    ));
+    // unmapped breakdown (fractions are of total unmapped reads)
+    let u = &m.unmapped;
+    let breakdown = [
+        ("Missing feature", u.missing_feature, u.missing_feature_frac),
+        (
+            "Failed UMI quality",
+            u.failed_umi_qual,
+            u.failed_umi_qual_frac,
+        ),
+        (
+            "Missing whitelist (barcode)",
+            u.missing_whitelist,
+            u.missing_whitelist_frac,
+        ),
+        ("Missing probe", u.missing_probe, u.missing_probe_frac),
+        ("UMI truncated", u.umi_truncated, u.umi_truncated_frac),
+    ];
+    let mut rows = String::new();
+    for (label, count, frac) in breakdown {
+        if count == 0 {
+            continue;
+        }
+        rows.push_str(&hbar(
+            label,
+            &format!("{} ({} of unmapped)", int(count), pct(frac)),
+            frac,
+            "var(--bad)",
+        ));
+    }
+    format!(
+        "<div class=\"card\"><h2>Read mapping</h2>\
+         <div class=\"hint\">{} total reads &middot; {} mapped &middot; {} unmapped</div>{bars}\
+         <div style=\"height:6px\"></div><div class=\"muted\" style=\"font-size:12px;margin-bottom:6px\">Unmapped reads by reason (share of unmapped):</div>{rows}</div>",
+        int(m.total_reads),
+        int(m.mapped_reads),
+        int(m.unmapped_reads),
+    )
+}
+
+fn probe_table(r: &SampleReport) -> String {
+    if r.probes.is_empty() {
+        return String::new();
+    }
+    let is_crispr = r.kind == SampleKind::Crispr;
+    let mut head = String::from(
+        "<tr><th>Probe</th><th>Barcodes</th><th>Reads</th><th>UMIs</th><th>Saturation</th>\
+         <th>Median reads/bc</th><th>Median UMIs/bc</th><th>UMI corr.</th>",
+    );
+    if is_crispr {
+        head.push_str("<th>Cells assigned</th><th>Dominant MOI</th>");
+    }
+    head.push_str("</tr>");
+
+    let mut body = String::new();
+    for p in &r.probes {
+        let umi_corr = p
+            .umi_corrected_frac
+            .map_or_else(|| "&mdash;".to_string(), pct);
+        let _ = write!(
+            body,
+            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td>",
+            esc(&p.name),
+            int(p.n_barcodes),
+            int(p.total_reads),
+            int(p.total_umis),
+            pct(p.saturation),
+            f1(p.median_reads_per_barcode),
+            f1(p.median_umis_per_barcode),
+            umi_corr,
+        );
+        if is_crispr {
+            if let Some(a) = &p.assignment {
+                let _ = write!(
+                    body,
+                    "<td>{} ({})</td><td>{}</td>",
+                    int(a.n_assigned),
+                    pct(a.assigned_frac),
+                    a.dominant_moi,
+                );
+            } else {
+                body.push_str("<td>&mdash;</td><td>&mdash;</td>");
+            }
+        }
+        body.push_str("</tr>");
+    }
+    format!(
+        "<div class=\"card\"><h2>Per-probe metrics</h2>\
+         <div class=\"hint\">Saturation = 1 &minus; UMIs / reads (endpoint). Medians are per observed barcode.</div>\
+         <div class=\"overflow\"><table><thead>{head}</thead><tbody>{body}</tbody></table></div></div>"
+    )
+}
+
+fn knee_card(r: &SampleReport) -> String {
+    let svg = knee_svg(&r.probes);
+    if svg.is_empty() {
+        return String::new();
+    }
+    format!(
+        "<div class=\"card\"><h2>Barcode-rank plot</h2>\
+         <div class=\"hint\">UMIs per barcode vs. rank (log&ndash;log). The knee separates cell-associated barcodes from background.</div>{svg}</div>"
+    )
+}
+
+fn moi_card(r: &SampleReport) -> String {
+    if r.kind != SampleKind::Crispr {
+        return String::new();
+    }
+    // Aggregate MOI distribution across probes.
+    let mut agg: std::collections::BTreeMap<i64, u64> = std::collections::BTreeMap::new();
+    for p in &r.probes {
+        if let Some(a) = &p.assignment {
+            for (moi, count) in &a.moi_distribution {
+                *agg.entry(*moi).or_insert(0) += *count;
+            }
+        }
+    }
+    if agg.is_empty() {
+        return String::new();
+    }
+    let max = agg.values().copied().max().unwrap_or(1).max(1) as f64;
+    let total: u64 = agg.values().copied().sum();
+    let mut rows = String::new();
+    for (moi, count) in agg.iter().take(15) {
+        let frac_total = *count as f64 / total as f64;
+        rows.push_str(&hbar(
+            &format!("MOI = {moi}"),
+            &format!("{} ({})", int(*count), pct(frac_total)),
+            *count as f64 / max,
+            "var(--accent)",
+        ));
+    }
+    format!(
+        "<div class=\"card\"><h2>Guide multiplicity (MOI)</h2>\
+         <div class=\"hint\">Number of assigned cells by guides-per-cell, across all probes ({} cells).</div>{rows}</div>",
+        int(total)
+    )
+}
+
+fn timings_card(r: &SampleReport) -> String {
+    if r.timings.is_empty() {
+        return String::new();
+    }
+    let mut agg: std::collections::BTreeMap<String, f64> = std::collections::BTreeMap::new();
+    for t in &r.timings {
+        *agg.entry(t.module.clone()).or_insert(0.0) += t.elapsed;
+    }
+    let max = agg.values().copied().fold(0.0_f64, f64::max).max(1e-9);
+    // Present in a stable, pipeline-ish order then any extras.
+    let order = [
+        "Mapping",
+        "InitialSort",
+        "UmiCorrection",
+        "ReadsDump",
+        "Counting",
+        "ConversionH5ad",
+        "DropletFiltering",
+        "GuideAssignment",
+    ];
+    let mut rows = String::new();
+    let mut seen: Vec<String> = Vec::new();
+    for name in order {
+        if let Some(sec) = agg.get(name) {
+            rows.push_str(&hbar(name, &fmt_dur(*sec), *sec / max, "var(--accent)"));
+            seen.push(name.to_string());
+        }
+    }
+    for (name, sec) in &agg {
+        if !seen.contains(name) {
+            rows.push_str(&hbar(name, &fmt_dur(*sec), *sec / max, "var(--accent)"));
+        }
+    }
+    format!(
+        "<div class=\"card\"><h2>Pipeline timing</h2>\
+         <div class=\"hint\">Wall-clock summed per module (post-mapping steps run in parallel across probes).</div>{rows}</div>"
+    )
+}
+
+fn fmt_dur(sec: f64) -> String {
+    if sec >= 3600.0 {
+        format!("{:.1} h", sec / 3600.0)
+    } else if sec >= 60.0 {
+        format!("{:.1} min", sec / 60.0)
+    } else {
+        format!("{sec:.1} s")
+    }
+}
+
+fn libraries_card(r: &SampleReport) -> String {
+    if r.libraries.is_empty() {
+        return String::new();
+    }
+    let mut body = String::new();
+    for l in &r.libraries {
+        let _ = write!(
+            body,
+            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+            esc(&l.name),
+            int(l.total_elem),
+            int(l.total_aggr),
+            esc(&l.mate),
+            l.window,
+            if l.exact { "exact" } else { "fuzzy" },
+        );
+    }
+    format!(
+        "<div class=\"card\"><h2>Reference libraries</h2>\
+         <div class=\"overflow\"><table><thead><tr><th>Library</th><th>Elements</th><th>Aggregated</th><th>Mate</th><th>Window</th><th>Match</th></tr></thead><tbody>{body}</tbody></table></div></div>"
+    )
+}
+
+fn notes_card(r: &SampleReport) -> String {
+    if r.notes.is_empty() {
+        return String::new();
+    }
+    let mut items = String::new();
+    for n in &r.notes {
+        let _ = write!(items, "<div class=\"note\">&#9888; {}</div>", esc(n));
+    }
+    format!("<div class=\"card\"><h2>Notes</h2>{items}</div>")
+}
+
+fn sample_kpis(r: &SampleReport) -> String {
+    let mut tiles = String::new();
+    let total_reads = r.mapping.as_ref().map_or(r.total_reads, |m| m.total_reads);
+    tiles.push_str(&kpi(&compact(total_reads), "Total reads"));
+    if let Some(m) = &r.mapping {
+        tiles.push_str(&kpi(&pct(m.mapped_reads_frac), "Reads mapped"));
+    }
+    if let Some(s) = r.overall_saturation {
+        tiles.push_str(&kpi(&pct(s), "Sequencing saturation"));
+    }
+    tiles.push_str(&kpi(&r.probes.len().to_string(), "Probes"));
+    tiles.push_str(&kpi(&compact(r.total_umis), "Total UMIs"));
+    let barcodes: u64 = r.probes.iter().map(|p| p.n_barcodes).sum();
+    tiles.push_str(&kpi(&compact(barcodes), "Barcodes observed"));
+    if r.kind == SampleKind::Crispr {
+        let assigned: u64 = r
+            .probes
+            .iter()
+            .filter_map(|p| p.assignment.as_ref().map(|a| a.n_assigned))
+            .sum();
+        if assigned > 0 {
+            tiles.push_str(&kpi(&compact(assigned), "Cells assigned"));
+        }
+    }
+    format!("<div class=\"kpis\">{tiles}</div>")
+}
+
+/// Render a full per-sample HTML report.
+pub fn render_sample(r: &SampleReport) -> String {
+    let kind_class = match r.kind {
+        SampleKind::Gex => "gex",
+        SampleKind::Crispr => "crispr",
+        SampleKind::Unknown => "unknown",
+    };
+    let runtime = r
+        .runtime_sec
+        .map(|s| format!(" &middot; mapping {}", fmt_dur(s)))
+        .unwrap_or_default();
+    let header = format!(
+        "<div class=\"top\"><h1>{}</h1><span class=\"badge {kind_class}\">{}</span></div>\
+         <div class=\"muted mono\" style=\"margin-top:-14px;margin-bottom:18px\">{}{runtime}</div>",
+        esc(&r.sample),
+        esc(r.kind.label()),
+        esc(&r.path),
+    );
+    let body = format!(
+        "{header}{}{}{}{}{}{}{}{}",
+        sample_kpis(r),
+        mapping_card(r),
+        probe_table(r),
+        knee_card(r),
+        moi_card(r),
+        timings_card(r),
+        libraries_card(r),
+        notes_card(r),
+    );
+    page(&format!("{} — cyto report", r.sample), &body)
+}
+
+// ---------------------------------------------------------------------------
+// master (cross-sample) report
+// ---------------------------------------------------------------------------
+
+/// Render an index over multiple samples, linking to each per-sample report.
+pub fn render_master(run_name: &str, reports: &[(&SampleReport, String)]) -> String {
+    let n = reports.len();
+    let total_reads: u64 = reports
+        .iter()
+        .map(|(r, _)| r.mapping.as_ref().map_or(r.total_reads, |m| m.total_reads))
+        .sum();
+    let total_umis: u64 = reports.iter().map(|(r, _)| r.total_umis).sum();
+
+    let mut tiles = String::new();
+    tiles.push_str(&kpi(&n.to_string(), "Samples"));
+    tiles.push_str(&kpi(&compact(total_reads), "Total reads"));
+    tiles.push_str(&kpi(&compact(total_umis), "Total UMIs"));
+    let kpis = format!("<div class=\"kpis\">{tiles}</div>");
+
+    let mut body_rows = String::new();
+    for (r, href) in reports {
+        let mapped = r
+            .mapping
+            .as_ref()
+            .map_or_else(|| "&mdash;".to_string(), |m| pct(m.mapped_reads_frac));
+        let sat = r
+            .overall_saturation
+            .map_or_else(|| "&mdash;".to_string(), pct);
+        let reads = r.mapping.as_ref().map_or(r.total_reads, |m| m.total_reads);
+        let assigned: u64 = r
+            .probes
+            .iter()
+            .filter_map(|p| p.assignment.as_ref().map(|a| a.n_assigned))
+            .sum();
+        let cells = if r.kind == SampleKind::Crispr && assigned > 0 {
+            int(assigned)
+        } else {
+            "&mdash;".to_string()
+        };
+        let _ = write!(
+            body_rows,
+            "<tr><td><a href=\"{}\">{}</a></td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+            esc(href),
+            esc(&r.sample),
+            esc(r.kind.label()),
+            int(reads),
+            mapped,
+            r.probes.len(),
+            int(r.total_umis),
+            sat,
+            cells,
+        );
+    }
+    let table = format!(
+        "<div class=\"card\"><h2>Samples</h2><div class=\"overflow\"><table><thead>\
+         <tr><th>Sample</th><th>Type</th><th>Reads</th><th>Mapped</th><th>Probes</th><th>UMIs</th><th>Saturation</th><th>Cells assigned</th></tr>\
+         </thead><tbody>{body_rows}</tbody></table></div></div>"
+    );
+
+    let header = format!(
+        "<div class=\"top\"><h1>{}</h1><span class=\"badge\">run</span></div>\
+         <div class=\"muted\" style=\"margin-top:-14px;margin-bottom:18px\">{n} sample report{}</div>",
+        esc(run_name),
+        if n == 1 { "" } else { "s" },
+    );
+    page(
+        &format!("{run_name} — cyto run report"),
+        &format!("{header}{kpis}{table}"),
+    )
+}

--- a/crates/cyto-summary/src/render.rs
+++ b/crates/cyto-summary/src/render.rs
@@ -152,6 +152,16 @@ fn f1(x: f64) -> String {
     format!("{x:.1}")
 }
 
+/// "Genes"/"Guides" label with a suffix, e.g. `feature_word(kind, "detected")`.
+fn feature_word(kind: SampleKind, suffix: &str) -> String {
+    let noun = if kind == SampleKind::Crispr {
+        "Guides"
+    } else {
+        "Genes"
+    };
+    format!("{noun} {suffix}")
+}
+
 fn metric(v: &str, k: &str) -> String {
     format!(
         "<div class=\"metric\"><div class=\"v\">{}</div><div class=\"k\">{}</div></div>",
@@ -351,6 +361,9 @@ fn sample_metrics(r: &SampleReport) -> String {
     m.push_str(&metric(&compact(r.total_umis), "UMIs"));
     let barcodes: u64 = r.probes.iter().map(|p| p.n_barcodes).sum();
     m.push_str(&metric(&compact(barcodes), "Barcodes"));
+    if let Some(det) = r.features_detected {
+        m.push_str(&metric(&int(det), &feature_word(r.kind, "detected")));
+    }
     if r.kind == SampleKind::Crispr {
         let assigned: u64 = r
             .probes
@@ -409,6 +422,30 @@ fn cells_section(r: &SampleReport) -> String {
             "<tr><td>Reads mapped</td><td>{}</td></tr>",
             pct(mp.mapped_reads_frac)
         );
+    }
+    if let Some(det) = r.features_detected {
+        let val = r
+            .features_total
+            .map_or_else(|| int(det), |tot| format!("{} / {}", int(det), int(tot)));
+        let _ = write!(
+            keys,
+            "<tr><td>{}</td><td>{val}</td></tr>",
+            feature_word(r.kind, "detected"),
+        );
+    }
+    if r.kind == SampleKind::Crispr {
+        let tested: u64 = r
+            .probes
+            .iter()
+            .filter_map(|p| p.assignment.as_ref().map(|a| a.n_tested))
+            .sum();
+        if tested > 0 {
+            let _ = write!(
+                keys,
+                "<tr><td>Cells tested (UMI threshold)</td><td>{}</td></tr>",
+                int(tested)
+            );
+        }
     }
     let _ = write!(keys, "<tr><td>Probes</td><td>{}</td></tr>", r.probes.len());
 
@@ -480,10 +517,19 @@ fn probe_section(r: &SampleReport) -> String {
         return String::new();
     }
     let is_crispr = r.kind == SampleKind::Crispr;
+    let detected_hdr = if is_crispr {
+        "Guides det."
+    } else {
+        "Genes det."
+    };
+    let has_detected = r.probes.iter().any(|p| p.features_detected.is_some());
     let mut head = String::from(
         "<tr><th>Probe</th><th>Barcodes</th><th>Reads</th><th>UMIs</th><th>Saturation</th>\
          <th>Median reads/bc</th><th>Median UMIs/bc</th><th>UMI corr.</th>",
     );
+    if has_detected {
+        let _ = write!(head, "<th>{detected_hdr}</th>");
+    }
     if is_crispr {
         head.push_str("<th>Cells assigned</th><th>Dom. MOI</th>");
     }
@@ -506,6 +552,14 @@ fn probe_section(r: &SampleReport) -> String {
             f1(p.median_umis_per_barcode),
             umi_corr,
         );
+        if has_detected {
+            let _ = write!(
+                body,
+                "<td>{}</td>",
+                p.features_detected
+                    .map_or_else(|| "&mdash;".to_string(), int),
+            );
+        }
         if is_crispr {
             if let Some(a) = &p.assignment {
                 let _ = write!(

--- a/crates/cyto/CLAUDE.md
+++ b/crates/cyto/CLAUDE.md
@@ -9,7 +9,7 @@ Main binary crate and entry point for the entire application. Parses top-level C
 - `src/main.rs` — CLI parsing (`Cli` struct via Clap), command routing via `match` on `Commands` enum, output directory validation
 - `src/logging.rs` — Logging infrastructure with two modes:
   - `setup_workflow_logging()` — Dual-output: stderr (with ANSI colors) + log file (ANSI-stripped), used for `map` and `workflow` commands
-  - `setup_default_logging()` — Standard stderr logging, used for `detect` and `ibu` subcommands
+  - `setup_default_logging()` — Standard stderr logging, used for `detect`, `ibu`, `summary`, and `download` subcommands
 
 ## Key Types
 

--- a/crates/cyto/Cargo.toml
+++ b/crates/cyto/Cargo.toml
@@ -23,6 +23,7 @@ cyto-ibu-reads = { workspace = true }
 cyto-ibu-sort = { workspace = true }
 cyto-io = { workspace = true }
 cyto-map = { workspace = true }
+cyto-summary = { workspace = true }
 cyto-workflow = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }

--- a/crates/cyto/Cargo.toml
+++ b/crates/cyto/Cargo.toml
@@ -30,5 +30,10 @@ env_logger = { workspace = true }
 
 strip-ansi-escapes = "0.2.1"
 
+[features]
+# Build `cyto summary` with genes/guides-detected metrics (links system libhdf5).
+# Off by default so the standard build and cross-compiled releases need no libhdf5.
+h5ad = ["cyto-summary/h5ad"]
+
 [lints]
 workspace = true

--- a/crates/cyto/src/main.rs
+++ b/crates/cyto/src/main.rs
@@ -46,7 +46,9 @@ fn main() -> Result<()> {
             wf.validate_outdir()?;
             setup_workflow_logging(wf.log_path())?;
         }
-        Commands::Detect(_) | Commands::Ibu(_) | Commands::Download(_) => setup_default_logging(),
+        Commands::Detect(_) | Commands::Ibu(_) | Commands::Summary(_) | Commands::Download(_) => {
+            setup_default_logging()
+        }
     }
 
     info!("Initializing...");
@@ -71,6 +73,7 @@ fn main() -> Result<()> {
             WorkflowCommand::GexMapping(args) => cyto_workflow::gex::run(&args),
             WorkflowCommand::CrisprMapping(args) => cyto_workflow::crispr::run(&args),
         },
+        Commands::Summary(args) => cyto_summary::run(&args),
         Commands::Download(args) => cyto_download::run(&args, env!("CARGO_PKG_VERSION")),
     }?;
     info!("Done!");

--- a/justfile
+++ b/justfile
@@ -25,6 +25,10 @@ install:
 install-portable:
     cargo install --path crates/cyto
 
+# Install with genes/guides-detected metrics (requires system libhdf5).
+install-h5ad:
+    export RUSTFLAGS="-C target-cpu=native"; cargo install --path crates/cyto --features h5ad
+
 run-wf-crispr:
     time cyto workflow crispr \
         -c {{ CRISPR_GUIDES }} \
@@ -58,6 +62,10 @@ run-wf-gex-unprobed:
         --geometry "{{ GEX_UNPROBED_GEOMETRY }}" \
         --force \
         {{ GEX_BINSEQ }}
+
+# Generate an HTML QC report from a finished gex workflow run
+run-summary: run-wf-gex
+    cyto summary ./cyto_out
 
 run-all: run-crispr-binseq run-crispr-fastq run-gex-binseq run-gex-fastq
 


### PR DESCRIPTION
## Summary

Adds a new `cyto summary <dir>...` subcommand (new `cyto-summary` crate) that turns finished output directories into **self-contained HTML QC reports** plus machine-readable JSON sidecars — cyto's answer to Cell Ranger's `web_summary.html`, built entirely from the per-stage stat files each workflow already writes. No reads/IBUs are reprocessed, so it is an aggregation/presentation layer with negligible runtime.

## Report contents

Per sample (`<sample>.cyto-report.html`):

- Headline metrics — reads, mapped %, sequencing saturation, UMIs, barcodes, genes/guides detected, cells
- Read-mapping funnel with a **per-reason unmapped breakdown** (missing probe/feature/whitelist, failed UMI quality)
- Cells & barcodes: library metrics + an inline-SVG **barcode-rank plot** (one line per probe)
- Per-probe table — reads, UMIs, endpoint saturation, per-barcode medians, UMI-correction rate, features detected
- CRISPR **guide multiplicity (MOI)** and guide-assignment / cells-tested
- Pipeline timing, reference libraries, and a notes panel for missing/malformed inputs

When several samples are present, a `<run>.cyto-report.html` master index links them, **split into Gene Expression and CRISPR columns**.

Output is self-contained: inlined CSS, hand-built SVG plots, no JS/plotting/templating dependencies — one portable KB-sized file per report (vs. the tens of MB `web_summary.html` embeds).

## Genes/guides detected — optional `h5ad` feature

`--features` reads the count matrices (h5ad) to report distinct genes/guides detected. This is gated behind an **off-by-default `h5ad` cargo feature** that links system `libhdf5`, so the default build, CI, and cross-compiled releases need no libhdf5. Build it with `cargo install --path crates/cyto --features h5ad` (or `just install-h5ad`). Column indices are streamed in chunks to handle hundred-million-nnz matrices, and the reader prefers a cell-filtered `.filt.h5ad` when present. On a build without the feature, `--features` warns and skips.

CI gains a `build-h5ad` lane (installs `libhdf5-dev`) that exercises the feature; the default build/test/lint jobs are unchanged and need no libhdf5.

## Notes

- Collection is **best-effort**: a missing or malformed stat file degrades an individual panel (recorded in a notes panel) rather than failing the report.
- Validated on a real 8-sample perturb-seq run; numbers cross-checked against the raw `stats/` files. `cargo test`, clippy (pedantic), and `fmt` are clean on both the default and `--features h5ad` builds.
- Per-crate `CLAUDE.md`, the README, and the justfile (`run-summary`, `install-h5ad`) are updated.

## Possible follow-ups (not in this PR)

- Analytic sequencing-saturation curve via a reads-per-UMI histogram emitted from `cyto-ibu-reads`
- GEX estimated-cells (surface `cell-filter` output, or a knee-based cell call)
- Optional UMAP/clustering panel
